### PR TITLE
feat: PQC 웹 서버 초기 구성 (OpenSSL 3 + oqs-provider + Nginx)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto eol=lf
+*.sh text eol=lf

--- a/.github/workflows/devsecops-pipeline.yml
+++ b/.github/workflows/devsecops-pipeline.yml
@@ -1,0 +1,87 @@
+name: DevSecOps PQC Pipeline
+
+# main/develop 브랜치 Push·PR 또는 수동 실행 시 파이프라인 작동
+on:
+  push:
+    branches: [ "main", "develop" ]
+  pull_request:
+    branches: [ "main", "develop" ]
+  workflow_dispatch:
+    inputs:
+      stage:
+        description: 'TLS Stage 선택 (1=ECC, 2=Hybrid, 3=PQ)'
+        required: true
+        default: '2'
+        type: choice
+        options:
+          - '1'
+          - '2'
+          - '3'
+
+jobs:
+  pqc-migration-pipeline:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 1. 저장소 코드 가져오기
+        uses: actions/checkout@v4
+
+      - name: 2. 정적 보안 분석 (SAST & Secret)
+        run: |
+          echo "진행 중: 코드 내 하드코딩된 키 및 취약점 스캔..."
+          # 추후 추가: python policy/sast_scan.py
+
+      - name: 3. TLS 암호 정책 검증 (Security Gate)
+        run: |
+          echo "진행 중: nginx.conf의 암호화 알고리즘 정책 준수 여부 확인..."
+          # 추후 추가: bash policy/check_tls_policy.sh
+          # 실패 시 파이프라인 여기서 강제 종료 (exit 1)
+
+      - name: 4. PQC Nginx 도커 빌드 및 가동
+        run: |
+          # workflow_dispatch 시 선택한 Stage로 nginx.conf 교체
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            STAGE="${{ github.event.inputs.stage }}"
+            if [ "$STAGE" = "1" ]; then
+              cp nginx/nginx-ecc.conf nginx/nginx.conf
+              echo "Stage 1: Classical TLS (ECC)로 설정"
+            elif [ "$STAGE" = "2" ]; then
+              cp nginx/nginx-hybrid.conf nginx/nginx.conf
+              echo "Stage 2: Hybrid PQC-TLS로 설정"
+            elif [ "$STAGE" = "3" ]; then
+              cp nginx/nginx-pq.conf nginx/nginx.conf
+              echo "Stage 3: Post-Quantum TLS로 설정"
+            fi
+          else
+            # push/PR 시: nginx.conf 내용으로 Stage 자동 감지
+            if grep -q "p521_mlkem\|p384_mlkem" nginx/nginx.conf; then
+              STAGE=3
+            elif grep -q "X25519MLKEM768\|x25519_mlkem" nginx/nginx.conf; then
+              STAGE=2
+            else
+              STAGE=1
+            fi
+            echo "nginx.conf에서 감지된 Stage: $STAGE"
+          fi
+          echo "STAGE=$STAGE" >> $GITHUB_ENV
+
+          echo "진행 중: OQS-Nginx 컨테이너 임시 구동..."
+          docker compose build
+          docker compose up -d
+          echo "서비스 시작 대기 중 (15초)..."
+          sleep 15
+          docker compose ps
+
+      - name: 5. 배포 후 동적 검증 (TLS 협상 확인)
+        run: |
+          echo "진행 중: 서버로 TLS 연결 시도 및 PQC 그룹 확인..."
+          docker exec tls-tester verify_tls.sh proxy-server 443 ${{ env.STAGE }}
+
+      - name: 6. CBOM 명세서 생성 및 리포팅
+        run: |
+          echo "진행 중: 현재 서버 암호 자산 목록(JSON) 추출..."
+          # 추후 추가: python policy/cbom_gen.py
+
+      - name: 컨테이너 정리
+        if: always()
+        run: docker compose down

--- a/.github/workflows/devsecops-pipeline.yml
+++ b/.github/workflows/devsecops-pipeline.yml
@@ -3,7 +3,7 @@ name: DevSecOps PQC Pipeline
 # main/develop 브랜치 Push·PR 또는 수동 실행 시 파이프라인 작동
 on:
   push:
-    branches: [ "main", "develop" ]
+    branches: [ "main", "develop", "feature/**" ]
   pull_request:
     branches: [ "main", "develop" ]
   workflow_dispatch:

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,9 @@ __pycache__/
 tester/captures/*.pcap
 
 *.log
+
+# 인증서
+**/certs/*.key
+**/certs/*.csr
+**/certs/*.srl
+**/certs/*.crt

--- a/README.md
+++ b/README.md
@@ -1,50 +1,191 @@
+# 2026 Secure Capstone — PQC Migration DevSecOps
+
+> 양자 컴퓨터 위협에 대비한 **Post-Quantum Cryptography(PQC) TLS 마이그레이션** 자동화 파이프라인 구축 프로젝트
+
+---
+
+## 프로젝트 개요
+
+현재 인터넷 암호화의 근간인 RSA, ECDH 등의 알고리즘은 양자 컴퓨터 공격에 취약합니다.
+이 프로젝트는 **기존 Classical TLS → Hybrid PQC-TLS → Full PQC-TLS** 단계적 마이그레이션을 구현하고,
+GitHub Actions 기반 **DevSecOps 파이프라인**으로 각 단계의 보안 게이트를 자동 검증합니다.
+
+### TLS 마이그레이션 3단계
+
+| Stage | 방식 | 키 교환 알고리즘 | 상태 |
+|:---:|---|---|:---:|
+| Stage 1 | Classical TLS | X25519, P-256 (ECC) | ✅ |
+| Stage 2 | Hybrid PQC-TLS | X25519MLKEM768 (ECC + ML-KEM) | ✅ |
+| Stage 3 | Post-Quantum TLS | p521_mlkem1024, p384_mlkem768 | ✅ |
+
+---
+
+## 시스템 구성
+
+```
+클라이언트 (tls-tester)
+      │  HTTPS (TLS 1.3 + PQC)
+      ▼
+[pqc-proxy]  openquantumsafe/nginx — PQC TLS 종단
+      │  HTTP
+      ▼
+[service-backend]  FastAPI — 백엔드 API
+```
+
+### 컨테이너 구성
+
+| 컨테이너 | 이미지 | 역할 |
+|---|---|---|
+| `pqc-proxy` | `openquantumsafe/nginx` | PQC TLS 프록시 |
+| `service-backend` | Python FastAPI | 백엔드 API 서버 |
+| `tls-tester` | `openquantumsafe/curl` | TLS 검증 도구 |
+
+---
+
 ## 시작하기 (Getting Started)
 
-### 1. 환경 구축 (Development Mode)
-실시간 코드 수정이 반영되는 개발 모드로 컨테이너를 실행합니다.
+### 사전 요구사항
+
+- Docker Desktop
+- Git
+
+### 1. 저장소 클론
+
 ```bash
-docker-compose up -d --build
+git clone <repository-url>
+cd 2026SecureCapstone
 ```
 
-### 2. 패킷 캡처 및 분석
-테스트 컨테이너 내에서 통신을 감시하고 로컬 폴더(`tester/captures`)로 추출합니다.
+### 2. 컨테이너 빌드 및 실행
 
 ```bash
-# 1. 컨테이너 접속 및 캡처 시작
-docker exec -it tls-tester /bin/bash
-tshark -i eth0 -w /data/capture_test.pcap
+docker compose up -d --build
+```
 
-# 2. (별도 터미널에서 트래픽 발생)
-docker exec -it tls-tester curl http://proxy-server
+> 인증서는 빌드 시 자동 생성됩니다. 별도 설정 불필요.
 
-# 3. 저장된 파일은 로컬의 ./tester/captures/ 폴더에서 Wireshark로 확인
+### 3. 동작 확인
+
+```bash
+docker compose ps
 ```
 
 ---
 
-## 프로젝트 로드맵 (Project Roadmap)
+## TLS Stage 전환
 
-- [x] Phase 1: 3-Tier 기반 도커 베이스라인 구축 및 네트워크 연동
-- [ ] Phase 2: OQS-OpenSSL(Post-Quantum) 엔진 빌드 및 Nginx 탑재
-- [ ] Phase 3: 양자 내성 암호 기반 인증서 발급 및 하이브리드 TLS 설정
-- [ ] Phase 4: GitHub Actions 기반 자동 보안 검증 파이프라인 연동
-- [ ] Phase 5: 성능 비교 분석 (전통적 암호 vs PQC) 및 최종 결과 도출
+### 방법 1: 직접 전환 (로컬)
+
+`nginx/nginx.conf` 파일을 원하는 Stage의 내용으로 교체 후 nginx 재시작:
+
+```bash
+# Stage 1 (Classical ECC)
+cp nginx/nginx-ecc.conf nginx/nginx.conf
+
+# Stage 2 (Hybrid PQC) — 기본값
+cp nginx/nginx-hybrid.conf nginx/nginx.conf
+
+# Stage 3 (Post-Quantum)
+cp nginx/nginx-pq.conf nginx/nginx.conf
+
+docker compose restart proxy-server
+```
+
+### 방법 2: GitHub Actions (자동)
+
+GitHub → Actions 탭 → **DevSecOps PQC Pipeline** → **Run workflow** → Stage 선택 → 실행
+
+파이프라인이 자동으로 nginx.conf 교체 → Docker 빌드 → TLS 검증까지 수행합니다.
 
 ---
 
-## 폴더 구조 (Directory Structure)
+## TLS 검증
+
+컨테이너 실행 중 tester에서 TLS 협상 결과 확인:
+
+```bash
+# Stage 1 검증
+docker exec -it tls-tester verify_tls.sh pqc-proxy 443 1
+
+# Stage 2 검증
+docker exec -it tls-tester verify_tls.sh pqc-proxy 443 2
+
+# Stage 3 검증
+docker exec -it tls-tester verify_tls.sh pqc-proxy 443 3
+```
+
+### 출력 예시 (Stage 2)
 
 ```
-2026capstone/
- ┣ 📂 nginx/                    # Nginx 및 OQS 빌드 환경
- ┣ 📂 backend/                  # FastAPI 기반 웹 서버 로직
- ┣ 📂 tester/                   # 검증용 툴 및 패킷 캡처 저장소
- ┣ 📜 docker-compose.yml        # 개발용 설정 (Volume 연동)
- ┣ 📜 docker-compose.prod.yml   # 배포용 설정 (Clean Build)
- ┗ 📜 README.md
+=== TLS 협상 결과 검증: pqc-proxy:443 (Stage: 2) ===
+
+=== 요약 ===
+Protocol : TLSv1.3
+Cipher   : TLS_AES_256_GCM_SHA384
+Key Group: X25519MLKEM768
+
+판정: Stage 2 - Hybrid PQC-TLS ✓
 ```
 
- ---
+> **💡 검증 스크립트 작성 시 주의사항**
+> Stage 2(`X25519MLKEM768`)와 Stage 3(`p521_mlkem1024` 등) 키 그룹 모두 `mlkem` 문자열을 포함합니다.
+> 단순히 `mlkem` 포함 여부로 분기하면 Stage 3를 Stage 2로 오판할 수 있습니다.
+> **정확한 판정 기준: `x25519` 기반이면 Stage 2, `p384`/`p521` 기반이면 Stage 3**
+
+---
+
+## CI/CD 파이프라인
+
+`main`, `develop` 브랜치에 Push 또는 PR 시 자동 실행됩니다.
+GitHub 웹 인터페이스에서 **수동으로 실행(workflow_dispatch)** 하여 특정 Stage 전환을 강제 테스트할 수도 있습니다.
+
+```
+1. 저장소 코드 가져오기
+2. 정적 보안 분석 (SAST & Secret 스캔)
+3. TLS 암호 정책 검증 (Security Gate)
+4. PQC Nginx Docker 빌드 및 가동
+5. 배포 후 동적 TLS 검증
+6. CBOM 명세서 생성
+```
+
+---
+
+## 폴더 구조
+
+```
+2026SecureCapstone/
+ ┣ 📂 .github/
+ ┃ ┗ 📂 workflows/
+ ┃   ┗ 📜 devsecops-pipeline.yml  # CI/CD 파이프라인
+ ┣ 📂 nginx/                      # OQS-Nginx 설정
+ ┃ ┣ 📜 Dockerfile
+ ┃ ┣ 📜 nginx.conf                # 활성 설정 (Stage 전환 대상)
+ ┃ ┣ 📜 nginx-ecc.conf            # Stage 1: Classical TLS
+ ┃ ┣ 📜 nginx-hybrid.conf         # Stage 2: Hybrid PQC-TLS
+ ┃ ┗ 📜 nginx-pq.conf             # Stage 3: Post-Quantum TLS
+ ┣ 📂 backend/                    # FastAPI 백엔드
+ ┣ 📂 tester/                     # TLS 검증 도구
+ ┃ ┣ 📜 Dockerfile
+ ┃ ┗ 📜 verify_tls.sh             # TLS 협상 검증 스크립트
+ ┣ 📂 pqc-webserver/              # WSL2 직접 설치 참고용 (레거시)
+ ┣ 📜 docker-compose.yml          # 개발용
+ ┣ 📜 docker-compose.prod.yml     # 배포용
+ ┣ 📜 .gitattributes              # LF 줄바꿈 강제
+ ┗ 📜 .gitignore
+```
+
+---
+
+## 프로젝트 로드맵
+
+- [x] Phase 1: 3-Tier 기반 Docker 베이스라인 구축 및 네트워크 연동
+- [x] Phase 2: OQS-Nginx 기반 PQC TLS 3단계 Docker 통합
+- [x] Phase 3: Hybrid PQC-TLS 검증 (X25519MLKEM768 협상 확인)
+- [x] Phase 4: GitHub Actions DevSecOps 파이프라인 구현 (workflow_dispatch)
+- [ ] Phase 5: SAST, TLS 정책 검증, CBOM 생성 구현
+- [ ] Phase 6: 성능 비교 분석 (Classical vs PQC) 및 최종 결과 도출
+
+---
 
 # 프로젝트 협업 규칙 (Contribution Guide)
 
@@ -67,9 +208,9 @@ docker exec -it tls-tester curl http://proxy-server
 | `Chore` | 빌드 업무, 패키지 매니저 설정, 프로젝트 설정 변경 |
 
 ### 예시 (Example)
-* `Feat: 구글 소셜 로그인 기능 구현`
-* `Fix: 메인 페이지 이미지 로딩 에러 수정`
-* `Docs: 설치 방법 안내 섹션 추가`
+* `Feat: Stage 2 하이브리드 PQC용 nginx.conf 추가`
+* `Fix: TLS 정책 검증 스크립트 정규식 파싱 오류 수정`
+* `Docs: CBOM 생성 아키텍처 다이어그램 추가`
 
 ---
 
@@ -80,11 +221,11 @@ docker exec -it tls-tester curl http://proxy-server
 * **`main`**: 배포 가능한 상태의 안정된 코드만 관리합니다.
 * **`develop`**: 다음 출시를 위한 개발을 진행하는 브랜치입니다.
 * **`feature/기능명`**: 새로운 기능을 개발할 때 사용합니다.
-    * 예: `feature/login`, `feature/chart-ui`
+    * 예: `feature/sast-scanner`, `feature/oqs-nginx`, `feature/github-actions`
 * **`hotfix/이슈명`**: 배포 후 긴급 수정이 필요할 때 사용합니다.
 * **`docs/기능명`**: 문서 수정이 필요할 때 사용합니다.
 
-기능 브랜치 -> develop -> main
+**Workflow:** `feature` 브랜치 작업 → PR 생성 → `develop` 병합 → 배포 시 `main` 병합
 
 ---
 
@@ -99,4 +240,3 @@ docker exec -it tls-tester curl http://proxy-server
     * 주의 사항 및 참고 자료 (Optional)
 
 ---
-

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -6,6 +6,8 @@ services:
       - "80:80"
       - "443:443"
     restart: always
+    volumes:
+      - ./nginx/nginx.conf:/opt/nginx/nginx-conf/nginx.conf
     depends_on:
       - backend-api
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - "80:80"
       - "443:443"
     volumes:
-      - ./nginx/nginx.conf:/etc/nginx/nginx.conf
+      - ./nginx/nginx.conf:/opt/nginx/nginx-conf/nginx.conf
     depends_on:
       - backend-api
     networks:

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,6 +1,22 @@
-FROM nginx:latest
+FROM openquantumsafe/nginx
+
+USER root
+
+# openssl 설치 및 인증서 자동 생성 (빌드 시 1회)
+RUN apk add --no-cache openssl && \
+    mkdir -p /etc/nginx/certs && \
+    openssl req -x509 -newkey rsa:2048 -days 365 \
+        -keyout /etc/nginx/certs/server.key \
+        -out /etc/nginx/certs/server.crt \
+        -subj "/C=KR/O=QuantumJump/CN=localhost" \
+        -nodes
 
 # 설정 파일을 컨테이너 안으로 복사
-COPY nginx.conf /etc/nginx/nginx.conf
+COPY nginx.conf /opt/nginx/nginx-conf/nginx.conf
+COPY nginx-ecc.conf /opt/nginx/nginx-conf/nginx-ecc.conf
+COPY nginx-hybrid.conf /opt/nginx/nginx-conf/nginx-hybrid.conf
+COPY nginx-pq.conf /opt/nginx/nginx-conf/nginx-pq.conf
 
 EXPOSE 80 443
+
+CMD ["nginx", "-c", "/opt/nginx/nginx-conf/nginx.conf", "-g", "daemon off;"]

--- a/nginx/nginx-ecc.conf
+++ b/nginx/nginx-ecc.conf
@@ -3,14 +3,13 @@ events {
 }
 
 http {
-    # HTTP → HTTPS 리다이렉트
     server {
         listen 80;
         server_name localhost;
         return 301 https://$host$request_uri;
     }
 
-    # Stage 2: Hybrid PQC-TLS (X25519MLKEM768)
+    # Stage 1: Classical TLS (ECC)
     server {
         listen 443 ssl;
         server_name localhost;
@@ -18,8 +17,9 @@ http {
         ssl_certificate     /etc/nginx/certs/server.crt;
         ssl_certificate_key /etc/nginx/certs/server.key;
 
-        ssl_protocols TLSv1.3;
-        ssl_ecdh_curve X25519MLKEM768:X25519;
+        ssl_protocols TLSv1.2 TLSv1.3;
+        ssl_ciphers ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384;
+        ssl_ecdh_curve X25519:prime256v1:secp384r1;
         ssl_prefer_server_ciphers on;
 
         location / {

--- a/nginx/nginx-hybrid.conf
+++ b/nginx/nginx-hybrid.conf
@@ -3,7 +3,6 @@ events {
 }
 
 http {
-    # HTTP → HTTPS 리다이렉트
     server {
         listen 80;
         server_name localhost;

--- a/nginx/nginx-pq.conf
+++ b/nginx/nginx-pq.conf
@@ -3,14 +3,13 @@ events {
 }
 
 http {
-    # HTTP → HTTPS 리다이렉트
     server {
         listen 80;
         server_name localhost;
         return 301 https://$host$request_uri;
     }
 
-    # Stage 2: Hybrid PQC-TLS (X25519MLKEM768)
+    # Stage 3: Post-Quantum TLS (실험적)
     server {
         listen 443 ssl;
         server_name localhost;
@@ -19,7 +18,7 @@ http {
         ssl_certificate_key /etc/nginx/certs/server.key;
 
         ssl_protocols TLSv1.3;
-        ssl_ecdh_curve X25519MLKEM768:X25519;
+        ssl_ecdh_curve p521_mlkem1024:p384_mlkem768;
         ssl_prefer_server_ciphers on;
 
         location / {

--- a/pqc-webserver/.env.example
+++ b/pqc-webserver/.env.example
@@ -1,0 +1,5 @@
+# 경로 설정 (복사 후 .env로 저장하여 사용)
+BASE_DIR=/home/yulimH/quantum-jump/pqc-webserver
+CERTS_DIR=${BASE_DIR}/certs
+NGINX_CONF_DIR=${BASE_DIR}/nginx
+CA_CERT=${CERTS_DIR}/ca.crt

--- a/pqc-webserver/.gitignore
+++ b/pqc-webserver/.gitignore
@@ -2,3 +2,4 @@ certs/*.key
 certs/*.csr
 certs/*.srl
 certs/*.crt
+.env

--- a/pqc-webserver/.gitignore
+++ b/pqc-webserver/.gitignore
@@ -1,5 +1,0 @@
-certs/*.key
-certs/*.csr
-certs/*.srl
-certs/*.crt
-.env

--- a/pqc-webserver/.gitignore
+++ b/pqc-webserver/.gitignore
@@ -1,0 +1,4 @@
+certs/*.key
+certs/*.csr
+certs/*.srl
+certs/*.crt

--- a/pqc-webserver/Makefile
+++ b/pqc-webserver/Makefile
@@ -1,0 +1,102 @@
+HOME_DIR := $(shell echo $$HOME)
+BASE_DIR  := $(HOME_DIR)/quantum-jump/pqc-webserver
+CERTS_DIR := $(BASE_DIR)/certs
+SCRIPTS_DIR := $(BASE_DIR)/scripts
+NGINX_DIR := $(BASE_DIR)/nginx
+
+.PHONY: all install certs stage1 stage2 stage3 verify1 verify2 verify3 status clean
+
+all: install certs
+	@echo "=== 전체 설치 완료 ==="
+
+## 빌드 및 설치 ##
+
+install: install-liboqs install-oqs-provider register-provider
+	@echo "=== oqs-provider 설치 완료 ==="
+
+install-liboqs:
+	@echo "--- liboqs 빌드 중 ---"
+	git clone --depth 1 https://github.com/open-quantum-safe/liboqs.git $(HOME_DIR)/liboqs
+	cmake -S $(HOME_DIR)/liboqs -B $(HOME_DIR)/liboqs/build \
+		-DOQS_DIST_BUILD=ON \
+		-DBUILD_SHARED_LIBS=ON \
+		-DCMAKE_INSTALL_PREFIX=/usr/local
+	cmake --build $(HOME_DIR)/liboqs/build --parallel $$(nproc)
+	sudo cmake --install $(HOME_DIR)/liboqs/build
+	sudo ldconfig
+
+install-oqs-provider:
+	@echo "--- oqs-provider 빌드 중 ---"
+	git clone --depth 1 https://github.com/open-quantum-safe/oqs-provider.git $(HOME_DIR)/oqs-provider
+	cmake -S $(HOME_DIR)/oqs-provider -B $(HOME_DIR)/oqs-provider/build \
+		-DCMAKE_INSTALL_PREFIX=/usr/local \
+		-Dliboqs_DIR=/usr/local/lib/cmake/liboqs
+	cmake --build $(HOME_DIR)/oqs-provider/build --parallel $$(nproc)
+	sudo cmake --install $(HOME_DIR)/oqs-provider/build
+	sudo ldconfig
+
+register-provider:
+	@echo "--- OpenSSL에 oqs-provider 등록 중 ---"
+	sudo sed -i '/\[kali_wide_compatibility_providers\]/a oqsprovider = oqs_sect' /etc/ssl/kali.cnf
+	@printf '\n[provider_sect]\ndefault = default_sect\noqsprovider = oqs_sect\n\n[default_sect]\nactivate = 1\n\n[oqs_sect]\nactivate = 1\nmodule = /usr/lib/x86_64-linux-gnu/ossl-modules/oqsprovider.so\n' | sudo tee -a /usr/lib/ssl/openssl.cnf
+	@echo "--- provider 등록 검증 ---"
+	openssl list -providers | grep oqsprovider
+
+## 인증서 생성 ##
+
+certs:
+	@echo "--- 인증서 생성 중 ---"
+	mkdir -p $(CERTS_DIR)
+	openssl genrsa -out $(CERTS_DIR)/ca.key 4096
+	openssl req -new -x509 -days 3650 -key $(CERTS_DIR)/ca.key -out $(CERTS_DIR)/ca.crt \
+		-subj "/C=KR/O=QuantumJump/CN=QuantumJump-CA"
+	openssl genrsa -out $(CERTS_DIR)/server.key 2048
+	openssl req -new -key $(CERTS_DIR)/server.key -out $(CERTS_DIR)/server.csr \
+		-subj "/C=KR/O=QuantumJump/CN=localhost"
+	openssl x509 -req -days 365 -in $(CERTS_DIR)/server.csr \
+		-CA $(CERTS_DIR)/ca.crt -CAkey $(CERTS_DIR)/ca.key -CAcreateserial \
+		-out $(CERTS_DIR)/server.crt
+	@echo "=== 인증서 생성 완료 ==="
+
+## TLS 단계 전환 ##
+
+stage1:
+	@echo "--- Stage 1: Classical TLS (ECC) 전환 ---"
+	sudo bash $(SCRIPTS_DIR)/switch_stage.sh 1
+	@$(MAKE) verify1
+
+stage2:
+	@echo "--- Stage 2: Hybrid PQC-TLS 전환 ---"
+	sudo bash $(SCRIPTS_DIR)/switch_stage.sh 2
+	@$(MAKE) verify2
+
+stage3:
+	@echo "--- Stage 3: Post-Quantum TLS 전환 (실험적) ---"
+	sudo bash $(SCRIPTS_DIR)/switch_stage.sh 3
+	@$(MAKE) verify3
+
+## TLS 검증 ##
+
+verify1:
+	bash $(SCRIPTS_DIR)/verify_tls.sh localhost 443 1
+
+verify2:
+	bash $(SCRIPTS_DIR)/verify_tls.sh localhost 443 2
+
+verify3:
+	bash $(SCRIPTS_DIR)/verify_tls.sh localhost 443 3
+
+## 상태 확인 ##
+
+status:
+	@echo "=== OpenSSL Provider 상태 ==="
+	openssl list -providers
+	@echo ""
+	@echo "=== Nginx 상태 ==="
+	sudo systemctl status nginx --no-pager
+
+## 정리 ##
+
+clean:
+	@echo "--- 빌드 디렉토리 정리 ---"
+	rm -rf $(HOME_DIR)/liboqs $(HOME_DIR)/oqs-provider

--- a/pqc-webserver/README.md
+++ b/pqc-webserver/README.md
@@ -1,0 +1,194 @@
+# Quantum Jump — PQC 웹 서버 설정 가이드
+
+팀원 1 (최유림) 담당: OpenSSL 3 + oqs-provider + Nginx TLS 단계별 전환 환경
+
+---
+
+## 환경 요구사항
+
+- WSL2 + Kali Linux (또는 Ubuntu 22.04 이상)
+- OpenSSL 3.x (Kali 기본 탑재)
+- 인터넷 연결 (GitHub clone)
+
+---
+
+## 1단계: 의존성 설치
+
+```bash
+sudo apt-get update && sudo apt-get upgrade -y
+sudo apt-get install -y build-essential cmake ninja-build libssl-dev git wget curl python3
+```
+
+---
+
+## 2단계: liboqs 빌드 및 설치
+
+```bash
+git clone --depth 1 https://github.com/open-quantum-safe/liboqs.git ~/liboqs
+cmake -S ~/liboqs -B ~/liboqs/build \
+    -DOQS_DIST_BUILD=ON \
+    -DBUILD_SHARED_LIBS=ON \
+    -DCMAKE_INSTALL_PREFIX=/usr/local
+cmake --build ~/liboqs/build --parallel $(nproc)
+sudo cmake --install ~/liboqs/build
+sudo ldconfig
+```
+
+---
+
+## 3단계: oqs-provider 빌드 및 설치
+
+```bash
+git clone --depth 1 https://github.com/open-quantum-safe/oqs-provider.git ~/oqs-provider
+cmake -S ~/oqs-provider -B ~/oqs-provider/build \
+    -DCMAKE_INSTALL_PREFIX=/usr/local \
+    -Dliboqs_DIR=/usr/local/lib/cmake/liboqs
+cmake --build ~/oqs-provider/build --parallel $(nproc)
+sudo cmake --install ~/oqs-provider/build
+sudo ldconfig
+```
+
+---
+
+## 4단계: OpenSSL에 oqs-provider 등록
+
+```bash
+# openssl.cnf에 oqs-provider 섹션 추가
+sudo tee -a /usr/lib/ssl/openssl.cnf << 'CNFEOF'
+
+[provider_sect]
+default = default_sect
+oqsprovider = oqs_sect
+
+[default_sect]
+activate = 1
+
+[oqs_sect]
+activate = 1
+module = /usr/lib/x86_64-linux-gnu/ossl-modules/oqsprovider.so
+CNFEOF
+
+# Kali Linux 한정: kali.cnf에 oqs-provider 추가
+sudo sed -i '/\[kali_wide_compatibility_providers\]/a oqsprovider = oqs_sect' /etc/ssl/kali.cnf
+```
+
+### 검증
+
+```bash
+openssl list -providers                      # oqsprovider 가 보이면 성공
+openssl list -kem-algorithms | grep -i mlkem # ML-KEM 알고리즘 목록 확인
+```
+
+---
+
+## 5단계: Nginx 설치
+
+```bash
+sudo apt-get install -y nginx
+```
+
+---
+
+## 6단계: 인증서 생성
+
+```bash
+mkdir -p ~/quantum-jump/pqc-webserver/certs
+cd ~/quantum-jump/pqc-webserver/certs
+
+# 자체 CA 생성
+openssl genrsa -out ca.key 4096
+openssl req -new -x509 -days 3650 -key ca.key -out ca.crt \
+    -subj "/C=KR/O=QuantumJump/CN=QuantumJump-CA"
+
+# 서버 인증서 생성 및 서명
+openssl genrsa -out server.key 2048
+openssl req -new -key server.key -out server.csr \
+    -subj "/C=KR/O=QuantumJump/CN=localhost"
+openssl x509 -req -days 365 -in server.csr \
+    -CA ca.crt -CAkey ca.key -CAcreateserial \
+    -out server.crt
+```
+
+> 인증서 파일은 .gitignore로 제외되어 있습니다. 각자 로컬에서 생성해야 합니다.
+
+---
+
+## 사용법
+
+### TLS 단계 전환
+
+```bash
+sudo bash ~/quantum-jump/pqc-webserver/scripts/switch_stage.sh 1   # Stage 1: Classical TLS (ECC)
+sudo bash ~/quantum-jump/pqc-webserver/scripts/switch_stage.sh 2   # Stage 2: Hybrid PQC-TLS
+sudo bash ~/quantum-jump/pqc-webserver/scripts/switch_stage.sh 3   # Stage 3: Post-Quantum TLS (실험적)
+```
+
+### TLS 협상 결과 검증
+
+```bash
+bash ~/quantum-jump/pqc-webserver/scripts/verify_tls.sh localhost 443 1
+bash ~/quantum-jump/pqc-webserver/scripts/verify_tls.sh localhost 443 2
+bash ~/quantum-jump/pqc-webserver/scripts/verify_tls.sh localhost 443 3
+```
+
+### 예상 결과
+
+| 단계 | Key Group | 판정 |
+|------|-----------|------|
+| Stage 1 | X25519 | Classical TLS (ECC) |
+| Stage 2 | X25519MLKEM768 | Hybrid PQC-TLS |
+| Stage 3 | — | 실험적 (표준 미확정) |
+
+---
+
+## Makefile 사용법
+
+```bash
+make all        # liboqs + oqs-provider 설치 + 인증서 생성 한번에
+make stage1     # Stage 1 전환 + 검증
+make stage2     # Stage 2 전환 + 검증
+make stage3     # Stage 3 전환 + 검증
+make verify1    # Stage 1 검증만
+make verify2    # Stage 2 검증만
+make verify3    # Stage 3 검증만
+make status     # OpenSSL provider 및 Nginx 상태 확인
+```
+
+---
+
+## 파일 구조
+
+```
+pqc-webserver/
+├── nginx/
+│   ├── nginx-ecc.conf       # Stage 1: Classical TLS
+│   ├── nginx-hybrid.conf    # Stage 2: Hybrid PQC-TLS
+│   └── nginx-pq.conf        # Stage 3: Post-Quantum TLS (실험적)
+├── certs/                   # 로컬에서 생성 (git 제외)
+│   ├── ca.key / ca.crt
+│   └── server.key / server.crt
+├── scripts/
+│   ├── switch_stage.sh      # 단계 전환 스크립트
+│   └── verify_tls.sh        # TLS 협상 검증 스크립트
+├── Makefile
+├── README.md
+└── .gitignore
+```
+
+---
+
+## 문제 해결
+
+**oqsprovider가 목록에 안 보일 때**
+
+```bash
+sudo ldconfig
+openssl list -providers
+```
+
+**Nginx 시작 실패 시**
+
+```bash
+sudo nginx -t
+sudo systemctl status nginx
+```

--- a/pqc-webserver/nginx/nginx-ecc.conf
+++ b/pqc-webserver/nginx/nginx-ecc.conf
@@ -1,0 +1,21 @@
+events {}
+
+http {
+    server {
+        listen 443 ssl;
+        server_name localhost;
+
+        ssl_certificate     /home/yulimH/quantum-jump/pqc-webserver/certs/server.crt;
+        ssl_certificate_key /home/yulimH/quantum-jump/pqc-webserver/certs/server.key;
+
+        ssl_protocols TLSv1.2 TLSv1.3;
+        ssl_ciphers ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384;
+        ssl_ecdh_curve X25519:prime256v1:secp384r1;
+        ssl_prefer_server_ciphers on;
+
+        location / {
+            return 200 "Stage 1: Classical TLS (ECC)\n";
+            add_header Content-Type text/plain;
+        }
+    }
+}

--- a/pqc-webserver/nginx/nginx-hybrid.conf
+++ b/pqc-webserver/nginx/nginx-hybrid.conf
@@ -1,0 +1,20 @@
+events {}
+
+http {
+    server {
+        listen 443 ssl;
+        server_name localhost;
+
+        ssl_certificate     /home/yulimH/quantum-jump/pqc-webserver/certs/server.crt;
+        ssl_certificate_key /home/yulimH/quantum-jump/pqc-webserver/certs/server.key;
+
+        ssl_protocols TLSv1.3;
+        ssl_ecdh_curve X25519MLKEM768:X25519;
+        ssl_prefer_server_ciphers on;
+
+        location / {
+            return 200 "Stage 2: Hybrid PQC-TLS (X25519MLKEM768)\n";
+            add_header Content-Type text/plain;
+        }
+    }
+}

--- a/pqc-webserver/nginx/nginx-pq.conf
+++ b/pqc-webserver/nginx/nginx-pq.conf
@@ -1,0 +1,20 @@
+events {}
+
+http {
+    server {
+        listen 443 ssl;
+        server_name localhost;
+
+        ssl_certificate     /home/yulimH/quantum-jump/pqc-webserver/certs/server.crt;
+        ssl_certificate_key /home/yulimH/quantum-jump/pqc-webserver/certs/server.key;
+
+        ssl_protocols TLSv1.3;
+        ssl_ecdh_curve p521_mlkem1024:p384_mlkem768;
+        ssl_prefer_server_ciphers on;
+
+        location / {
+            return 200 "Stage 3: Post-Quantum TLS (실험적)\n";
+            add_header Content-Type text/plain;
+        }
+    }
+}

--- a/pqc-webserver/scripts/switch_stage.sh
+++ b/pqc-webserver/scripts/switch_stage.sh
@@ -1,7 +1,17 @@
 #!/bin/bash
 
+# .env 로드
+SCRIPT_DIR=$(dirname "$(realpath "$0")")
+ENV_FILE="$SCRIPT_DIR/../.env"
+
+if [ -f "$ENV_FILE" ]; then
+    source "$ENV_FILE"
+else
+    echo "오류: .env 파일이 없습니다. .env.example을 복사하여 .env를 생성하세요."
+    exit 1
+fi
+
 STAGE=$1
-NGINX_CONF_DIR=/home/yulimH/quantum-jump/pqc-webserver/nginx
 
 case $STAGE in
     1|ecc)
@@ -22,4 +32,4 @@ case $STAGE in
         ;;
 esac
 
-nginx -t && systemctl start nginx && echo "Nginx 재시작 완료"
+nginx -t && systemctl restart nginx && echo "Nginx 재시작 완료"

--- a/pqc-webserver/scripts/switch_stage.sh
+++ b/pqc-webserver/scripts/switch_stage.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+STAGE=$1
+NGINX_CONF_DIR=/home/yulimH/quantum-jump/pqc-webserver/nginx
+
+case $STAGE in
+    1|ecc)
+        cp $NGINX_CONF_DIR/nginx-ecc.conf /etc/nginx/nginx.conf
+        echo "Stage 1: Classical TLS (ECC)로 전환"
+        ;;
+    2|hybrid)
+        cp $NGINX_CONF_DIR/nginx-hybrid.conf /etc/nginx/nginx.conf
+        echo "Stage 2: Hybrid PQC-TLS로 전환"
+        ;;
+    3|pq)
+        cp $NGINX_CONF_DIR/nginx-pq.conf /etc/nginx/nginx.conf
+        echo "Stage 3: Post-Quantum TLS로 전환"
+        ;;
+    *)
+        echo "사용법: $0 {1|ecc|2|hybrid|3|pq}"
+        exit 1
+        ;;
+esac
+
+nginx -t && systemctl start nginx && echo "Nginx 재시작 완료"

--- a/pqc-webserver/scripts/verify_tls.sh
+++ b/pqc-webserver/scripts/verify_tls.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+HOST=${1:-localhost}
+PORT=${2:-443}
+STAGE=${3:-auto}
+
+echo "=== TLS 협상 결과 검증: $HOST:$PORT (Stage: $STAGE) ==="
+echo ""
+
+if [ "$STAGE" = "1" ] || [ "$STAGE" = "ecc" ]; then
+    RESULT=$(openssl s_client -connect $HOST:$PORT \
+        -CAfile /home/yulimH/quantum-jump/pqc-webserver/certs/ca.crt \
+        -groups x25519:prime256v1:secp384r1 -brief 2>&1 </dev/null)
+elif [ "$STAGE" = "2" ] || [ "$STAGE" = "hybrid" ]; then
+    RESULT=$(openssl s_client -connect $HOST:$PORT \
+        -CAfile /home/yulimH/quantum-jump/pqc-webserver/certs/ca.crt \
+        -groups X25519MLKEM768:x25519 -brief 2>&1 </dev/null)
+elif [ "$STAGE" = "3" ] || [ "$STAGE" = "pq" ]; then
+    RESULT=$(openssl s_client -connect $HOST:$PORT \
+        -CAfile /home/yulimH/quantum-jump/pqc-webserver/certs/ca.crt \
+        -groups p521_mlkem1024:p384_mlkem768 -brief 2>&1 </dev/null)
+else
+    RESULT=$(openssl s_client -connect $HOST:$PORT \
+        -CAfile /home/yulimH/quantum-jump/pqc-webserver/certs/ca.crt \
+        -brief 2>&1 </dev/null)
+fi
+
+echo "$RESULT"
+echo ""
+
+PROTOCOL=$(echo "$RESULT" | grep "Protocol version" | awk '{print $NF}')
+CIPHER=$(echo "$RESULT" | grep "Ciphersuite" | awk '{print $NF}')
+GROUP=$(echo "$RESULT" | grep -E "Negotiated TLS1.3 group|Peer Temp Key" | cut -d: -f2- | tr -d ' ')
+
+echo "=== 요약 ==="
+echo "Protocol : $PROTOCOL"
+echo "Cipher   : $CIPHER"
+echo "Key Group: $GROUP"
+
+if echo "$GROUP" | grep -qi "MLKEM\|mlkem"; then
+    if echo "$GROUP" | grep -qi "X25519\|p256\|p384"; then
+        echo "판정: Stage 2 - Hybrid PQC-TLS"
+    else
+        echo "판정: Stage 3 - Post-Quantum TLS"
+    fi
+else
+    echo "판정: Stage 1 - Classical TLS (ECC)"
+fi

--- a/pqc-webserver/scripts/verify_tls.sh
+++ b/pqc-webserver/scripts/verify_tls.sh
@@ -1,5 +1,16 @@
 #!/bin/bash
 
+# .env 로드
+SCRIPT_DIR=$(dirname "$(realpath "$0")")
+ENV_FILE="$SCRIPT_DIR/../.env"
+
+if [ -f "$ENV_FILE" ]; then
+    source "$ENV_FILE"
+else
+    echo "오류: .env 파일이 없습니다. .env.example을 복사하여 .env를 생성하세요."
+    exit 1
+fi
+
 HOST=${1:-localhost}
 PORT=${2:-443}
 STAGE=${3:-auto}
@@ -9,19 +20,19 @@ echo ""
 
 if [ "$STAGE" = "1" ] || [ "$STAGE" = "ecc" ]; then
     RESULT=$(openssl s_client -connect $HOST:$PORT \
-        -CAfile /home/yulimH/quantum-jump/pqc-webserver/certs/ca.crt \
+        -CAfile $CA_CERT \
         -groups x25519:prime256v1:secp384r1 -brief 2>&1 </dev/null)
 elif [ "$STAGE" = "2" ] || [ "$STAGE" = "hybrid" ]; then
     RESULT=$(openssl s_client -connect $HOST:$PORT \
-        -CAfile /home/yulimH/quantum-jump/pqc-webserver/certs/ca.crt \
+        -CAfile $CA_CERT \
         -groups X25519MLKEM768:x25519 -brief 2>&1 </dev/null)
 elif [ "$STAGE" = "3" ] || [ "$STAGE" = "pq" ]; then
     RESULT=$(openssl s_client -connect $HOST:$PORT \
-        -CAfile /home/yulimH/quantum-jump/pqc-webserver/certs/ca.crt \
+        -CAfile $CA_CERT \
         -groups p521_mlkem1024:p384_mlkem768 -brief 2>&1 </dev/null)
 else
     RESULT=$(openssl s_client -connect $HOST:$PORT \
-        -CAfile /home/yulimH/quantum-jump/pqc-webserver/certs/ca.crt \
+        -CAfile $CA_CERT \
         -brief 2>&1 </dev/null)
 fi
 

--- a/tester/Dockerfile
+++ b/tester/Dockerfile
@@ -1,13 +1,14 @@
-FROM kalilinux/kali-rolling
+FROM openquantumsafe/curl
 
-ENV DEBIAN_FRONTEND=noninteractive
+USER root
 
 # 필수 네트워크 및 검증 도구 설치
-RUN apt-get update && apt-get install -y \
-    curl \
-    wget \
+RUN apk add --no-cache \
+    bash \
     nmap \
     net-tools \
-    iputils-ping \
-    tshark \
-    && rm -rf /var/lib/apt/lists/*
+    iputils
+
+COPY verify_tls.sh /usr/local/bin/verify_tls.sh
+RUN sed -i 's/\r//' /usr/local/bin/verify_tls.sh && \
+    chmod +x /usr/local/bin/verify_tls.sh

--- a/tester/verify_tls.sh
+++ b/tester/verify_tls.sh
@@ -62,7 +62,10 @@ if [[ "$GROUP_LOWER" == *"mlkem"* ]]; then
     fi
 else
     echo "판정: Stage 1 - Classical TLS (ECC) - PQC 미적용"
-    exit 1
+    if [ "$STAGE" = "2" ] || [ "$STAGE" = "hybrid" ] || [ "$STAGE" = "3" ] || [ "$STAGE" = "pq" ]; then
+        echo "[!] 오류: PQC TLS 연결이 필요하지만 협상에 실패했습니다."
+        exit 1
+    fi
 fi
 
 exit 0

--- a/tester/verify_tls.sh
+++ b/tester/verify_tls.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+HOST=${1:-proxy-server}
+PORT=${2:-443}
+STAGE=${3:-auto}
+
+echo "=== TLS 협상 결과 검증: $HOST:$PORT (Stage: $STAGE) ==="
+echo ""
+
+# 안전한 임시 파일 관리
+TMPFILE=$(mktemp)
+trap 'rm -f "$TMPFILE"' EXIT INT TERM
+
+# Stage별 커브 설정
+if [ "$STAGE" = "1" ] || [ "$STAGE" = "ecc" ]; then
+    CURVES="x25519:prime256v1:secp384r1"
+elif [ "$STAGE" = "2" ] || [ "$STAGE" = "hybrid" ]; then
+    CURVES="X25519MLKEM768:x25519"
+elif [ "$STAGE" = "3" ] || [ "$STAGE" = "pq" ]; then
+    CURVES="p521_mlkem1024:p384_mlkem768"
+else
+    CURVES=""
+fi
+
+# curl 실행
+if [ -n "$CURVES" ]; then
+    curl -k -v --connect-timeout 5 --curves "$CURVES" https://"$HOST":"$PORT"/ > "$TMPFILE" 2>&1
+else
+    curl -k -v --connect-timeout 5 https://"$HOST":"$PORT"/ > "$TMPFILE" 2>&1
+fi
+
+# 연결 실패 확인
+if ! grep -q "SSL connection using" "$TMPFILE"; then
+    echo "[!] 오류: TLS 연결에 실패했거나 SSL 정보를 가져올 수 없습니다."
+    echo "상세 에러 로그:"
+    tail -n 3 "$TMPFILE"
+    exit 1
+fi
+
+SSL_LINE=$(grep "SSL connection using" "$TMPFILE" | head -n 1)
+
+# 추출 로직 (불필요한 공백 제거)
+PROTOCOL=$(echo "$SSL_LINE" | awk -F'/' '{print $1}' | grep -oE 'TLSv[0-9.]+')
+CIPHER=$(echo "$SSL_LINE" | awk -F'/' '{print $2}' | tr -d ' ')
+GROUP=$(echo "$SSL_LINE" | awk -F'/' '{print $3}' | tr -d ' ')
+
+echo "=== 요약 ==="
+echo "Protocol : ${PROTOCOL:-Unknown}"
+echo "Cipher   : ${CIPHER:-Unknown}"
+echo "Key Group: ${GROUP:-Unknown}"
+echo ""
+
+# 판정 로직 (X25519 기반 = Stage 2, P-curve 기반 = Stage 3)
+GROUP_LOWER=$(echo "$GROUP" | tr '[:upper:]' '[:lower:]')
+
+if [[ "$GROUP_LOWER" == *"mlkem"* ]]; then
+    if [[ "$GROUP_LOWER" == *"x25519"* ]]; then
+        echo "판정: Stage 2 - Hybrid PQC-TLS ✓"
+    else
+        # p521_mlkem1024, p384_mlkem768 등 P-curve + MLKEM
+        echo "판정: Stage 3 - Post-Quantum TLS ✓"
+    fi
+else
+    echo "판정: Stage 1 - Classical TLS (ECC) - PQC 미적용"
+    exit 1
+fi
+
+exit 0


### PR DESCRIPTION
## 작업 내용
- OpenSSL 3 + liboqs + oqs-provider 빌드 및 설치
- Nginx TLS 단계별 설정 파일 3종 작성 (ECC / Hybrid PQC / Post-Quantum)
- 단계 전환 스크립트 (switch_stage.sh)
- TLS 협상 결과 검증 스크립트 (verify_tls.sh)
- Makefile 및 README.md 작성

## 검증 결과
- Stage 1: X25519 → Classical TLS (ECC) ✓
- Stage 2: X25519MLKEM768 → Hybrid PQC-TLS ✓
- Stage 3: 실험적 (표준 미확정)

## 참고
- WSL2 + Kali Linux 환경 기준
- 모든 파일은 pqc-webserver/ 폴더 하위에 위치

---

## 피드백 반영 사항
- PR 대상 브랜치를 main → develop 으로 변경
- .gitignore에 certs/ 하위 키·인증서 파일 전체 제외 추가
- 누락됐던 nginx 설정 파일, 스크립트, Makefile, README 추가

---

## 피드백 반영 (2차)
- 하드코딩된 경로를 .env 파일로 분리 (.env.example 제공)
- .gitignore에 .env 추가
- systemctl start → systemctl restart 로 수정