### PR TITLE
feat: Docker 호환 TLS 단계 마이그레이션 구조 추가

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -6,8 +6,8 @@ services:
       - "80:80"
       - "443:443"
     restart: always
-    volumes:
-      - ./nginx/nginx.conf:/opt/nginx/nginx-conf/nginx.conf
+    environment:
+      - TLS_STAGE=${TLS_STAGE:-1}
     depends_on:
       - backend-api
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,8 @@ services:
     ports:
       - "80:80"
       - "443:443"
-    volumes:
-      - ./nginx/nginx.conf:/opt/nginx/nginx-conf/nginx.conf
+    environment:
+      - TLS_STAGE=${TLS_STAGE:-1}
     depends_on:
       - backend-api
     networks:

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -2,7 +2,7 @@ FROM openquantumsafe/nginx
 
 USER root
 
-# openssl 설치 및 인증서 자동 생성 (빌드 시 1회)
+# RSA 인증서 생성 (Stage 1 ECC / Stage 2 Hybrid 공용)
 RUN apk add --no-cache openssl && \
     mkdir -p /etc/nginx/certs && \
     openssl req -x509 -newkey rsa:2048 -days 365 \
@@ -17,6 +17,12 @@ COPY nginx-ecc.conf /opt/nginx/nginx-conf/nginx-ecc.conf
 COPY nginx-hybrid.conf /opt/nginx/nginx-conf/nginx-hybrid.conf
 COPY nginx-pq.conf /opt/nginx/nginx-conf/nginx-pq.conf
 
+COPY entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+# 기본 Stage: 1 (ECC)
+ENV TLS_STAGE=1
+
 EXPOSE 80 443
 
-CMD ["nginx", "-c", "/opt/nginx/nginx-conf/nginx.conf", "-g", "daemon off;"]
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/nginx/entrypoint.sh
+++ b/nginx/entrypoint.sh
@@ -16,15 +16,15 @@ CONF_DIR="/opt/nginx/nginx-conf"
 case "${TLS_STAGE:-1}" in
   1|ecc)
     echo "[entrypoint] Stage 1: Classical TLS (ECC) → nginx-ecc.conf 적용"
-    cp "$CONF_DIR/nginx-ecc.conf" "$CONF_DIR/nginx.conf"
+    cp -f "$CONF_DIR/nginx-ecc.conf" "$CONF_DIR/nginx.conf"
     ;;
   2|hybrid)
     echo "[entrypoint] Stage 2: Hybrid PQC-TLS → nginx-hybrid.conf 적용"
-    cp "$CONF_DIR/nginx-hybrid.conf" "$CONF_DIR/nginx.conf"
+    cp -f "$CONF_DIR/nginx-hybrid.conf" "$CONF_DIR/nginx.conf"
     ;;
   3|pq)
     echo "[entrypoint] Stage 3: Post-Quantum TLS → nginx-pq.conf 적용"
-    cp "$CONF_DIR/nginx-pq.conf" "$CONF_DIR/nginx.conf"
+    cp -f "$CONF_DIR/nginx-pq.conf" "$CONF_DIR/nginx.conf"
     ;;
   *)
     echo "[entrypoint] 오류: TLS_STAGE=${TLS_STAGE} 는 유효하지 않습니다. {1|ecc|2|hybrid|3|pq}"

--- a/nginx/entrypoint.sh
+++ b/nginx/entrypoint.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+# entrypoint.sh — Docker 컨테이너 시작 시 TLS_STAGE에 따라 nginx 설정 선택
+# switch_stage.sh의 Docker 호환 버전 (systemctl 미사용)
+#
+# TLS_STAGE: 1(ecc) | 2(hybrid) | 3(pq)  — 기본값: 1
+#
+# 사용법:
+#   docker compose up                          # Stage 1 (ECC)
+#   TLS_STAGE=2 docker compose up              # Stage 2 (Hybrid)
+#   TLS_STAGE=3 docker compose up              # Stage 3 (PQ-only)
+
+set -e
+
+CONF_DIR="/opt/nginx/nginx-conf"
+
+case "${TLS_STAGE:-1}" in
+  1|ecc)
+    echo "[entrypoint] Stage 1: Classical TLS (ECC) → nginx-ecc.conf 적용"
+    cp "$CONF_DIR/nginx-ecc.conf" "$CONF_DIR/nginx.conf"
+    ;;
+  2|hybrid)
+    echo "[entrypoint] Stage 2: Hybrid PQC-TLS → nginx-hybrid.conf 적용"
+    cp "$CONF_DIR/nginx-hybrid.conf" "$CONF_DIR/nginx.conf"
+    ;;
+  3|pq)
+    echo "[entrypoint] Stage 3: Post-Quantum TLS → nginx-pq.conf 적용"
+    cp "$CONF_DIR/nginx-pq.conf" "$CONF_DIR/nginx.conf"
+    ;;
+  *)
+    echo "[entrypoint] 오류: TLS_STAGE=${TLS_STAGE} 는 유효하지 않습니다. {1|ecc|2|hybrid|3|pq}"
+    exit 1
+    ;;
+esac
+
+exec nginx -c "$CONF_DIR/nginx.conf" -g 'daemon off;'

--- a/nginx/entrypoint.sh
+++ b/nginx/entrypoint.sh
@@ -16,15 +16,15 @@ CONF_DIR="/opt/nginx/nginx-conf"
 case "${TLS_STAGE:-1}" in
   1|ecc)
     echo "[entrypoint] Stage 1: Classical TLS (ECC) → nginx-ecc.conf 적용"
-    cp -f "$CONF_DIR/nginx-ecc.conf" "$CONF_DIR/nginx.conf"
+    rm -f "$CONF_DIR/nginx.conf" && cp "$CONF_DIR/nginx-ecc.conf" "$CONF_DIR/nginx.conf"
     ;;
   2|hybrid)
     echo "[entrypoint] Stage 2: Hybrid PQC-TLS → nginx-hybrid.conf 적용"
-    cp -f "$CONF_DIR/nginx-hybrid.conf" "$CONF_DIR/nginx.conf"
+    rm -f "$CONF_DIR/nginx.conf" && cp "$CONF_DIR/nginx-hybrid.conf" "$CONF_DIR/nginx.conf"
     ;;
   3|pq)
     echo "[entrypoint] Stage 3: Post-Quantum TLS → nginx-pq.conf 적용"
-    cp -f "$CONF_DIR/nginx-pq.conf" "$CONF_DIR/nginx.conf"
+    rm -f "$CONF_DIR/nginx.conf" && cp "$CONF_DIR/nginx-pq.conf" "$CONF_DIR/nginx.conf"
     ;;
   *)
     echo "[entrypoint] 오류: TLS_STAGE=${TLS_STAGE} 는 유효하지 않습니다. {1|ecc|2|hybrid|3|pq}"

--- a/nginx/entrypoint.sh
+++ b/nginx/entrypoint.sh
@@ -27,7 +27,7 @@ case "${TLS_STAGE:-1}" in
     rm -f "$CONF_DIR/nginx.conf" && cp "$CONF_DIR/nginx-pq.conf" "$CONF_DIR/nginx.conf"
     ;;
   *)
-    echo "[entrypoint] 오류: TLS_STAGE=${TLS_STAGE} 는 유효하지 않습니다. {1|ecc|2|hybrid|3|pq}"
+    echo "[entrypoint] 오류: TLS_STAGE=${TLS_STAGE} 는 유효하지 않습니다. {1|ecc|2|hybrid|3|pq}" >&2
     exit 1
     ;;
 esac

--- a/nginx/gen-certs.sh
+++ b/nginx/gen-certs.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# gen-certs.sh — TLS 인증서 생성 스크립트
+#
+# Stage 1/2: RSA-2048 인증서 (시스템 openssl)
+# Stage 3:   Dilithium3 인증서 (OQS-OpenSSL, Docker 필요)
+#
+# 사용법: bash nginx/gen-certs.sh
+# 생성 위치: /etc/nginx/certs/ (컨테이너 내부) → 빌드 시 자동 생성됨
+#            로컬 테스트용: nginx/certs/
+
+set -e
+
+CERTS_DIR="$(cd "$(dirname "$0")" && pwd)/certs"
+mkdir -p "$CERTS_DIR"
+
+# ─────────────────────────────────────────────────────────
+# Stage 1 & 2 공용: RSA-2048 인증서
+# ─────────────────────────────────────────────────────────
+echo "=== [1/2] RSA-2048 인증서 생성 (Stage 1 ECC / Stage 2 Hybrid 공용) ==="
+openssl req -x509 -newkey rsa:2048 -days 365 \
+  -keyout "$CERTS_DIR/server.key" \
+  -out    "$CERTS_DIR/server.crt" \
+  -subj "/C=KR/O=QuantumJump/CN=localhost" \
+  -nodes
+echo "    → server.key / server.crt 생성 완료"
+
+# ─────────────────────────────────────────────────────────
+# Stage 3 전용: Dilithium3 인증서 (OQS-OpenSSL via Docker)
+# ─────────────────────────────────────────────────────────
+echo "=== [2/2] Dilithium3 인증서 생성 (Stage 3 PQ-only 전용) ==="
+docker run --rm \
+  -v "$CERTS_DIR:/certs" \
+  openquantumsafe/oqs-ossl3:latest \
+  sh -c "
+    openssl req -x509 -newkey dilithium3 \
+      -keyout /certs/dilithium3.key \
+      -out    /certs/dilithium3.crt \
+      -days 365 -nodes \
+      -subj '/C=KR/O=QuantumJump/CN=localhost'
+    chmod 644 /certs/dilithium3.key /certs/dilithium3.crt
+  "
+echo "    → dilithium3.key / dilithium3.crt 생성 완료"
+
+echo ""
+echo "=== 완료 ==="
+ls -la "$CERTS_DIR"

--- a/nginx/gen-certs.sh
+++ b/nginx/gen-certs.sh
@@ -37,7 +37,7 @@ docker run --rm \
       -out    /certs/dilithium3.crt \
       -days 365 -nodes \
       -subj '/C=KR/O=QuantumJump/CN=localhost'
-    chmod 644 /certs/dilithium3.key /certs/dilithium3.crt
+    chmod 600 /certs/dilithium3.key; chmod 644 /certs/dilithium3.crt
   "
 echo "    → dilithium3.key / dilithium3.crt 생성 완료"
 

--- a/nginx/nginx-pq.conf
+++ b/nginx/nginx-pq.conf
@@ -9,7 +9,7 @@ http {
         return 301 https://$host$request_uri;
     }
 
-    # Stage 3: Post-Quantum TLS (실험적)
+    # Stage 3: PQC 강제 적용 — X25519MLKEM768만 허용, 클래식 폴백 없음
     server {
         listen 443 ssl;
         server_name localhost;
@@ -18,7 +18,7 @@ http {
         ssl_certificate_key /etc/nginx/certs/server.key;
 
         ssl_protocols TLSv1.3;
-        ssl_ecdh_curve p521_mlkem1024:p384_mlkem768;
+        ssl_ecdh_curve X25519MLKEM768;
         ssl_prefer_server_ciphers on;
 
         location / {

--- a/nginx/nginx-pq.conf
+++ b/nginx/nginx-pq.conf
@@ -9,7 +9,7 @@ http {
         return 301 https://$host$request_uri;
     }
 
-    # Stage 3: PQC 강제 적용 — X25519MLKEM768만 허용, 클래식 폴백 없음
+    # Stage 3: PQC 강제 적용 — p521_mlkem1024:p384_mlkem768만 허용, 클래식 폴백 없음
     server {
         listen 443 ssl;
         server_name localhost;
@@ -18,7 +18,7 @@ http {
         ssl_certificate_key /etc/nginx/certs/server.key;
 
         ssl_protocols TLSv1.3;
-        ssl_ecdh_curve X25519MLKEM768;
+        ssl_ecdh_curve p521_mlkem1024:p384_mlkem768;
         ssl_prefer_server_ciphers on;
 
         location / {

--- a/tester/verify_tls.sh
+++ b/tester/verify_tls.sh
@@ -17,7 +17,7 @@ if [ "$STAGE" = "1" ] || [ "$STAGE" = "ecc" ]; then
 elif [ "$STAGE" = "2" ] || [ "$STAGE" = "hybrid" ]; then
     CURVES="X25519MLKEM768:x25519"
 elif [ "$STAGE" = "3" ] || [ "$STAGE" = "pq" ]; then
-    CURVES="p521_mlkem1024:p384_mlkem768"
+    CURVES="X25519MLKEM768"
 else
     CURVES=""
 fi
@@ -50,19 +50,34 @@ echo "Cipher   : ${CIPHER:-Unknown}"
 echo "Key Group: ${GROUP:-Unknown}"
 echo ""
 
-# 판정 로직 (X25519 기반 = Stage 2, P-curve 기반 = Stage 3)
 GROUP_LOWER=$(echo "$GROUP" | tr '[:upper:]' '[:lower:]')
 
-if [[ "$GROUP_LOWER" == *"mlkem"* ]]; then
-    if [[ "$GROUP_LOWER" == *"x25519"* ]]; then
-        echo "판정: Stage 2 - Hybrid PQC-TLS ✓"
+if [ "$STAGE" = "3" ] || [ "$STAGE" = "pq" ]; then
+    # Stage 3: PQC 연결 성공 확인 후 클래식 폴백 차단 검증
+    if [[ "$GROUP_LOWER" == *"mlkem"* ]]; then
+        echo "판정: PQC 연결 성공 ✓"
+        echo "검증 중: 클래식 전용 클라이언트 차단 여부..."
+        CLASSIC_RESULT=$(curl -k --connect-timeout 5 --curves "x25519:prime256v1" \
+            https://"$HOST":"$PORT"/ 2>&1)
+        if echo "$CLASSIC_RESULT" | grep -q "handshake failure\|SSL"; then
+            echo "판정: Stage 3 - PQC 강제 적용 ✓ (클래식 폴백 차단 확인)"
+        else
+            echo "[!] 경고: 클래식 클라이언트도 연결됨 — 폴백 차단 미확인"
+            exit 1
+        fi
     else
-        # p521_mlkem1024, p384_mlkem768 등 P-curve + MLKEM
-        echo "판정: Stage 3 - Post-Quantum TLS ✓"
+        echo "[!] 오류: PQC TLS 연결이 필요하지만 협상에 실패했습니다."
+        exit 1
+    fi
+elif [[ "$GROUP_LOWER" == *"mlkem"* ]]; then
+    echo "판정: Stage 2 - Hybrid PQC-TLS ✓"
+    if [ "$STAGE" = "1" ] || [ "$STAGE" = "ecc" ]; then
+        echo "[!] 오류: Classical TLS가 필요하지만 PQC가 협상되었습니다."
+        exit 1
     fi
 else
     echo "판정: Stage 1 - Classical TLS (ECC) - PQC 미적용"
-    if [ "$STAGE" = "2" ] || [ "$STAGE" = "hybrid" ] || [ "$STAGE" = "3" ] || [ "$STAGE" = "pq" ]; then
+    if [ "$STAGE" = "2" ] || [ "$STAGE" = "hybrid" ]; then
         echo "[!] 오류: PQC TLS 연결이 필요하지만 협상에 실패했습니다."
         exit 1
     fi


### PR DESCRIPTION
## 개요
기존 `switch_stage.sh`는 `systemctl restart nginx`를 사용해 Docker 환경에서 동작 불가.
컨테이너 시작 시 환경변수(`TLS_STAGE`)로 TLS 단계를 선택하는 Docker 호환 방식으로 구현.

## 변경 사항
- `nginx/entrypoint.sh`: `TLS_STAGE` 값에 따라 ecc/hybrid/pq conf 선택 후 nginx 기동
- `nginx/Dockerfile`: `CMD` → `ENTRYPOINT` 교체, `TLS_STAGE` 기본값 1 설정
- `nginx/gen-certs.sh`: Stage 3용 Dilithium3 인증서 생성 스크립트 (OQS-OpenSSL via Docker)
- `docker-compose*.yml`: nginx.conf 볼륨 마운트 제거, `TLS_STAGE` env var 추가

## 사용법
TLS_STAGE=1 docker compose up --build  # Stage 1: ECC
TLS_STAGE=2 docker compose up --build  # Stage 2: Hybrid
TLS_STAGE=3 docker compose up --build  # Stage 3: PQ-only