### PR TITLE
CycloneDX 형식으로 변경

### DIFF
--- a/.github/workflows/devsecops-pipeline.yml
+++ b/.github/workflows/devsecops-pipeline.yml
@@ -222,21 +222,30 @@ jobs:
             --stage ${{ env.STAGE }} \
             --out artifacts/cbom_stage${{ env.STAGE }}.json
 
-          # 고전 암호 탐지 결과를 CBOM에 통합
+          # 고전 암호 탐지 결과를 CycloneDX CBOM properties에 통합
           python3 -c "
           import json, os
+
           cbom_path = 'artifacts/cbom_stage${{ env.STAGE }}.json'
           findings_path = 'artifacts/crypto-findings.json'
 
           with open(cbom_path) as f:
               cbom = json.load(f)
 
-          # 고전 암호 탐지 결과 추가
+          def set_property(bom, name, value):
+              rendered = json.dumps(value, ensure_ascii=False) if isinstance(value, (dict, list)) else str(value)
+              props = bom.setdefault('properties', [])
+              for p in props:
+                  if p.get('name') == name:
+                      p['value'] = rendered
+                      return
+              props.append({'name': name, 'value': rendered})
+
           if os.path.exists(findings_path):
               with open(findings_path) as f:
                   findings = json.load(f)
               results = findings.get('results', [])
-              cbom['classical_crypto_findings'] = [
+              crypto_findings = [
                   {
                       'file': r['path'],
                       'line': r['start']['line'],
@@ -247,21 +256,23 @@ jobs:
                   }
                   for r in results
               ]
-              cbom['migration_summary'] = {
+              set_property(cbom, 'securecapstone:classical_crypto_findings', crypto_findings)
+              set_property(cbom, 'securecapstone:migration_summary', {
                   'auto_migrated': 'nginx TLS configuration',
                   'manual_action_required': len(results),
                   'status': 'PARTIAL' if results else 'COMPLETE'
-              }
+              })
           else:
-              cbom['migration_summary'] = {
+              set_property(cbom, 'securecapstone:classical_crypto_findings', [])
+              set_property(cbom, 'securecapstone:migration_summary', {
                   'auto_migrated': 'nginx TLS configuration',
                   'manual_action_required': 0,
                   'status': 'COMPLETE'
-              }
+              })
 
           with open(cbom_path, 'w') as f:
               json.dump(cbom, f, indent=2, ensure_ascii=False)
-          print('[DONE] CBOM에 마이그레이션 결과 통합 완료')
+          print('[DONE] CycloneDX CBOM properties에 마이그레이션 결과 통합 완료')
           "
 
           # 이전 실행 CBOM 다운로드 후 마이그레이션 진척도 비교
@@ -309,8 +320,8 @@ jobs:
           GITLEAKS=$(jq -r '.tools.gitleaks // "unknown"' scanner/results/scan-summary.json 2>/dev/null || echo "unknown")
           SEMGREP=$(jq -r '.tools.semgrep // "unknown"' scanner/results/scan-summary.json 2>/dev/null || echo "unknown")
           FINDINGS=$(jq '.results | length' artifacts/crypto-findings.json 2>/dev/null || echo 0)
-          PROGRESS=$(jq -r '.migration_progress.status // "N/A"' "artifacts/cbom_stage${STAGE}.json" 2>/dev/null || echo "N/A")
-          MANUAL=$(jq -r '.migration_summary.manual_action_required // "N/A"' "artifacts/cbom_stage${STAGE}.json" 2>/dev/null || echo "N/A")
+          PROGRESS=$(jq -r '[.properties[]? | select(.name == "securecapstone:migration_progress")] | .[0].value // "{}" | fromjson | .status // "N/A"' "artifacts/cbom_stage${STAGE}.json" 2>/dev/null || echo "N/A")
+          MANUAL=$(jq -r '[.properties[]? | select(.name == "securecapstone:migration_summary")] | .[0].value // "{}" | fromjson | .manual_action_required // "N/A"' "artifacts/cbom_stage${STAGE}.json" 2>/dev/null || echo "N/A")
 
           icon() { [ "$1" = "pass" ] && echo "✅" || echo "❌"; }
 
@@ -353,9 +364,18 @@ jobs:
             let findings = 0, progress = 'N/A', manual = 'N/A';
             try {
               const cbom = JSON.parse(fs.readFileSync(`artifacts/cbom_stage${stage}.json`, 'utf8'));
-              findings = cbom.classical_crypto_findings?.length || 0;
-              progress = cbom.migration_progress?.status || 'N/A';
-              manual = cbom.migration_summary?.manual_action_required ?? 'N/A';
+              const props = cbom.properties || [];
+              const getProp = (name) => {
+                const p = props.find(x => x.name === name);
+                if (!p) return null;
+                try { return JSON.parse(p.value); } catch { return p.value; }
+              };
+              const findingsData = getProp('securecapstone:classical_crypto_findings');
+              findings = Array.isArray(findingsData) ? findingsData.length : 0;
+              const progressData = getProp('securecapstone:migration_progress');
+              progress = progressData?.status || 'N/A';
+              const summaryData = getProp('securecapstone:migration_summary');
+              manual = summaryData?.manual_action_required ?? 'N/A';
             } catch(e) {}
 
             const icon = (r) => r === 'pass' ? '✅' : r === 'fail' ? '❌' : '⚠️';

--- a/.github/workflows/devsecops-pipeline.yml
+++ b/.github/workflows/devsecops-pipeline.yml
@@ -230,8 +230,6 @@ jobs:
 
           if [ "$CBOM_RC" -eq 2 ]; then
             echo "[WARN] cbom_gen.py 동적 분석 실패(exit 2) — 부분 CBOM으로 후속 리포팅 계속 진행"
-          elif [ "$CBOM_RC" -eq 3 ]; then
-            echo "[WARN] cbom_gen.py 교차 검증 불일치(exit 3) — 생성된 CBOM으로 후속 리포팅 계속 진행"
           elif [ "$CBOM_RC" -ne 0 ]; then
             echo "[FATAL] cbom_gen.py 비정상 종료 (exit ${CBOM_RC})"
             exit "$CBOM_RC"
@@ -375,9 +373,6 @@ jobs:
 
           if [ "${{ steps.cbom_report.outputs.cbom_gen_exit_code }}" = "2" ]; then
             echo "[FATAL] cbom_gen.py 동적 분석 실패(exit 2)"
-            FAIL=1
-          elif [ "${{ steps.cbom_report.outputs.cbom_gen_exit_code }}" = "3" ]; then
-            echo "[FATAL] cbom_gen.py 교차 검증 불일치(exit 3)"
             FAIL=1
           fi
 

--- a/.github/workflows/devsecops-pipeline.yml
+++ b/.github/workflows/devsecops-pipeline.yml
@@ -211,16 +211,36 @@ jobs:
           docker compose ps
 
       - name: 9. 배포 후 동적 검증 (TLS 협상 확인)
+        id: tls_validate
+        continue-on-error: true
         run: |
           echo "진행 중: 서버로 TLS 연결 시도 및 PQC 그룹 확인..."
           docker exec tls-tester tls_check.sh proxy-server 443 ${{ env.STAGE }}
 
       - name: 10. CBOM 명세서 생성 및 리포팅
+        id: cbom_report
+        if: always()
         run: |
           echo "진행 중: 현재 서버 암호 자산 목록(JSON) 추출..."
-          python policy/cbom_gen.py \
-            --stage ${{ env.STAGE }} \
-            --out artifacts/cbom_stage${{ env.STAGE }}.json
+
+          CBOM_RC=0
+          python policy/cbom_gen.py --stage ${{ env.STAGE }} --out artifacts/cbom_stage${{ env.STAGE }}.json || CBOM_RC=$?
+
+          echo "cbom_gen_exit_code=${CBOM_RC}" >> "$GITHUB_OUTPUT"
+
+          if [ "$CBOM_RC" -eq 2 ]; then
+            echo "[WARN] cbom_gen.py 동적 분석 실패(exit 2) — 부분 CBOM으로 후속 리포팅 계속 진행"
+          elif [ "$CBOM_RC" -eq 3 ]; then
+            echo "[WARN] cbom_gen.py 교차 검증 불일치(exit 3) — 생성된 CBOM으로 후속 리포팅 계속 진행"
+          elif [ "$CBOM_RC" -ne 0 ]; then
+            echo "[FATAL] cbom_gen.py 비정상 종료 (exit ${CBOM_RC})"
+            exit "$CBOM_RC"
+          fi
+
+          if [ ! -f "artifacts/cbom_stage${{ env.STAGE }}.json" ]; then
+            echo "[FATAL] CBOM 출력 파일이 생성되지 않았습니다."
+            exit 1
+          fi
 
           # 고전 암호 탐지 결과를 CycloneDX CBOM properties에 통합
           python3 -c "
@@ -320,8 +340,8 @@ jobs:
           GITLEAKS=$(jq -r '.tools.gitleaks // "unknown"' scanner/results/scan-summary.json 2>/dev/null || echo "unknown")
           SEMGREP=$(jq -r '.tools.semgrep // "unknown"' scanner/results/scan-summary.json 2>/dev/null || echo "unknown")
           FINDINGS=$(jq '.results | length' artifacts/crypto-findings.json 2>/dev/null || echo 0)
-          PROGRESS=$(jq -r '[.properties[]? | select(.name == "securecapstone:migration_progress")] | .[0].value // "{}" | fromjson | .status // "N/A"' "artifacts/cbom_stage${STAGE}.json" 2>/dev/null || echo "N/A")
-          MANUAL=$(jq -r '[.properties[]? | select(.name == "securecapstone:migration_summary")] | .[0].value // "{}" | fromjson | .manual_action_required // "N/A"' "artifacts/cbom_stage${STAGE}.json" 2>/dev/null || echo "N/A")
+          PROGRESS=$(jq -r '[.properties[]? | select(.name == "securecapstone:migration_progress")] | .[0].value // "{}" | (try fromjson catch {}) | .status // "N/A"' "artifacts/cbom_stage${STAGE}.json" 2>/dev/null || echo "N/A")
+          MANUAL=$(jq -r '[.properties[]? | select(.name == "securecapstone:migration_summary")] | .[0].value // "{}" | (try fromjson catch {}) | .manual_action_required // "N/A"' "artifacts/cbom_stage${STAGE}.json" 2>/dev/null || echo "N/A")
 
           icon() { [ "$1" = "pass" ] && echo "✅" || echo "❌"; }
 
@@ -342,6 +362,28 @@ jobs:
           - 수동 조치 필요: **${MANUAL}건**
           - 진척도: **${PROGRESS}**
           SUMMARY
+
+      - name: 동적 검증/CBOM 상태 최종 반영
+        if: always()
+        run: |
+          FAIL=0
+
+          if [ "${{ steps.tls_validate.outcome }}" = "failure" ]; then
+            echo "[FATAL] Step 9 동적 TLS 검증 실패"
+            FAIL=1
+          fi
+
+          if [ "${{ steps.cbom_report.outputs.cbom_gen_exit_code }}" = "2" ]; then
+            echo "[FATAL] cbom_gen.py 동적 분석 실패(exit 2)"
+            FAIL=1
+          elif [ "${{ steps.cbom_report.outputs.cbom_gen_exit_code }}" = "3" ]; then
+            echo "[FATAL] cbom_gen.py 교차 검증 불일치(exit 3)"
+            FAIL=1
+          fi
+
+          if [ "$FAIL" -ne 0 ]; then
+            exit 1
+          fi
 
       - name: PR 보안 리포트 코멘트
         if: always() && github.event_name == 'pull_request'

--- a/policy/cbom_diff.py
+++ b/policy/cbom_diff.py
@@ -1,9 +1,13 @@
 #!/usr/bin/env python3
 """
-cbom_diff.py — CBOM 마이그레이션 이력 비교
+cbom_diff.py — CycloneDX CBOM 마이그레이션 이력 비교
 
-이전 실행의 CBOM과 현재 CBOM을 비교하여 migration_progress 필드를 추가합니다.
+이전 실행의 CycloneDX CBOM과 현재 CBOM을 비교하여
+migration_progress 정보를 properties에 추가합니다.
 파이프라인 Step 10에서 호출됩니다.
+
+CycloneDX 1.6 형식에서는 커스텀 데이터가 top-level "properties" 배열에
+securecapstone: 네임스페이스로 저장됩니다.
 
 Usage:
   python policy/cbom_diff.py --current <path> --previous <path> --out <path>
@@ -23,18 +27,56 @@ def load_json(path):
         return None
 
 
+def get_property(bom, name):
+    """CycloneDX BOM의 top-level properties에서 특정 이름의 값을 꺼낸다."""
+    for p in bom.get("properties", []):
+        if p.get("name") == name:
+            raw = p.get("value", "")
+            try:
+                return json.loads(raw)
+            except (json.JSONDecodeError, TypeError):
+                return raw
+    return None
+
+
+def set_property(bom, name, value):
+    """CycloneDX BOM의 top-level properties에 값을 설정(덮어쓰기)한다."""
+    if isinstance(value, (dict, list)):
+        rendered = json.dumps(value, ensure_ascii=False)
+    elif isinstance(value, bool):
+        rendered = "true" if value else "false"
+    else:
+        rendered = str(value)
+
+    props = bom.setdefault("properties", [])
+
+    for p in props:
+        if p.get("name") == name:
+            p["value"] = rendered
+            return
+
+    props.append({"name": name, "value": rendered})
+
+
 def finding_key(r):
     return f"{r['file']}:{r['line']}:{r['rule']}"
 
 
-def compare(current, previous):
-    curr_count = current.get("migration_summary", {}).get("manual_action_required", 0)
-    curr_findings = {finding_key(r) for r in current.get("classical_crypto_findings", [])}
+def compare(current_bom, previous_bom):
+    """현재·이전 CBOM의 마이그레이션 정보를 비교하여 진척도 dict를 반환."""
+    migration_summary = get_property(current_bom, "securecapstone:migration_summary") or {}
+    findings = get_property(current_bom, "securecapstone:classical_crypto_findings") or []
+
+    curr_count = 0
+    if isinstance(migration_summary, dict):
+        curr_count = migration_summary.get("manual_action_required", 0)
+    curr_findings = set()
+    if isinstance(findings, list):
+        curr_findings = {finding_key(r) for r in findings if isinstance(r, dict)}
 
     now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
-    if previous is None:
-        # 첫 실행 — 기준선
+    if previous_bom is None:
         return {
             "compared_at": now,
             "status": "BASELINE",
@@ -43,8 +85,15 @@ def compare(current, previous):
             "delta": 0,
         }
 
-    prev_count = previous.get("migration_summary", {}).get("manual_action_required", 0)
-    prev_findings = {finding_key(r) for r in previous.get("classical_crypto_findings", [])}
+    prev_summary = get_property(previous_bom, "securecapstone:migration_summary") or {}
+    prev_findings_list = get_property(previous_bom, "securecapstone:classical_crypto_findings") or []
+
+    prev_count = 0
+    if isinstance(prev_summary, dict):
+        prev_count = prev_summary.get("manual_action_required", 0)
+    prev_findings = set()
+    if isinstance(prev_findings_list, list):
+        prev_findings = {finding_key(r) for r in prev_findings_list if isinstance(r, dict)}
 
     resolved = sorted(prev_findings - curr_findings)
     new_findings = sorted(curr_findings - prev_findings)
@@ -110,7 +159,7 @@ def print_summary(progress):
 
 
 def main():
-    parser = argparse.ArgumentParser(description="CBOM 마이그레이션 이력 비교")
+    parser = argparse.ArgumentParser(description="CycloneDX CBOM 마이그레이션 이력 비교")
     parser.add_argument("--current", required=True, help="현재 CBOM JSON 경로")
     parser.add_argument("--previous", required=True, help="이전 CBOM JSON 경로 (없으면 BASELINE)")
     parser.add_argument("--out", required=True, help="출력 CBOM JSON 경로")
@@ -124,13 +173,15 @@ def main():
     previous = load_json(args.previous)
 
     progress = compare(current, previous)
-    current["migration_progress"] = progress
+
+    # CycloneDX properties에 migration_progress 추가
+    set_property(current, "securecapstone:migration_progress", progress)
 
     with open(args.out, "w") as f:
         json.dump(current, f, indent=2, ensure_ascii=False)
 
     print_summary(progress)
-    print(f"[DONE] migration_progress 필드 추가 완료 → {args.out}")
+    print(f"[DONE] securecapstone:migration_progress 속성 추가 완료 → {args.out}")
 
 
 if __name__ == "__main__":

--- a/policy/cbom_gen.py
+++ b/policy/cbom_gen.py
@@ -1,35 +1,55 @@
 """
-TLS Termination CBOM Generator
-================================
+TLS Termination CBOM Generator (CycloneDX 1.6)
+=================================================
 nginx TLS 설정(정적 분석) + 실제 핸드셰이크/인증서 정보(동적 분석)를 결합해
-TLS Termination 범위의 암호 자산을 JSON으로 기록한다.
+TLS Termination 범위의 암호 자산을 CycloneDX 1.6 CBOM(JSON)으로 기록한다.
 
-repo 기준 (feature/pqc-webserver-fix 브랜치):
+CycloneDX 1.6 spec: https://cyclonedx.org/docs/1.6/json/
+OWASP Dependency-Track, cdxgen, grype 등 생태계 도구와 호환된다.
+
+repo 기준:
 - nginx stage 설정 파일: nginx/nginx-ecc.conf, nginx/nginx-hybrid.conf, nginx/nginx-pq.conf
-- tester 컨테이너: tls-tester  (curl 기반 verify_tls.sh)
+- tester 컨테이너: tls-tester  (curl 기반 tls_check.sh)
 - server 컨테이너: pqc-proxy
 - 기본 검증 호스트: proxy-server
-- verify_tls.sh 실행 방식: docker exec tls-tester verify_tls.sh proxy-server 443 <stage>
+- tls_check.sh 실행 방식: docker exec tls-tester tls_check.sh proxy-server 443 <stage>
 
-CI 파이프라인 연동 (devsecops-pipeline.yml Step 6):
+CI 파이프라인 연동 (devsecops-pipeline.yml Step 10):
   python policy/cbom_gen.py --stage $STAGE --out artifacts/cbom_stage${STAGE}.json
 
 로컬 실행 예시:
   python policy/cbom_gen.py --stage 2 --out artifacts/cbom_stage2.json
+
+CycloneDX CLI로 검증:
+  cyclonedx validate --input-file artifacts/cbom_stage2.json --spec-version 1.6
+
+Exit codes:
+  0 - 정상
+  2 - 동적 분석 실패 (검증 스크립트 오류 포함)
+  3 - 교차 검증 불일치 (--strict-validation 시)
 """
 
 import argparse
+import hashlib
 import json
 import os
 import re
 import shlex
 import subprocess
 import sys
+import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 
 
-# ── 단계별 nginx 설정 파일 매핑 ──────────────────────────────────────────────
+# ── 상수 ──────────────────────────────────────────────────────────────────────
+GENERATOR_NAME = "cbom_gen.py"
+GENERATOR_VERSION = "2.2.1"
+
+CYCLONEDX_SCHEMA_MAP = {
+    "1.6": "https://cyclonedx.org/schema/bom-1.6.schema.json",
+}
+
 STAGE_CONFIG_MAP = {
     "1": "nginx/nginx-ecc.conf",
     "2": "nginx/nginx-hybrid.conf",
@@ -52,22 +72,47 @@ DEFAULT_SERVER = os.getenv("SERVER_CONTAINER", "pqc-proxy")
 DEFAULT_CERT_PATH = os.getenv("SERVER_CERT_PATH", "/etc/nginx/certs/server.crt")
 DEFAULT_VERIFY_SCRIPT = os.getenv("VERIFY_SCRIPT", "tls_check.sh")
 DEFAULT_STRICT_VALIDATION = os.getenv("STRICT_VALIDATION", "false").strip().lower() in {
-    "1", "true", "yes", "on"
+    "1", "true", "yes", "on",
+}
+DEFAULT_SPEC_VERSION = os.getenv("CYCLONEDX_SPEC_VERSION", "1.6")
+DEFAULT_REDACT = os.getenv("CBOM_REDACT", "true").strip().lower() not in {
+    "0", "false", "no", "off",
 }
 
 
-# ── PQC 알고리즘 패턴 (명시적 매칭) ──────────────────────────────────────────
+# ── PQC 알고리즘 패턴 ────────────────────────────────────────────────────────
 # Stage 2: X25519 + MLKEM 하이브리드 — [_\s]* 로 구분자 유무 모두 커버
 HYBRID_PQC_PATTERNS = [
-    re.compile(r"x25519[_\s]*mlkem", re.IGNORECASE),
+    re.compile(r"x25519[_\s-]*ml[-_\s]?kem", re.IGNORECASE),
 ]
 # Stage 3: P-curve + MLKEM 또는 순수 PQC
 # 두 번째 패턴은 negative lookbehind로 하이브리드 문자열 내 오매칭을 방지
 PURE_PQC_PATTERNS = [
-    re.compile(r"p\d+[_\s]*mlkem", re.IGNORECASE),
-    re.compile(r"(?<![a-zA-Z\d])mlkem\d+", re.IGNORECASE),
+    re.compile(r"p\d+[_\s-]*ml[-_\s]?kem", re.IGNORECASE),
+    re.compile(r"(?<![a-zA-Z\d])ml[-_\s]?kem[-_\s]?\d+", re.IGNORECASE),
 ]
 
+PQC_CERT_ALGORITHMS = [
+    "dilithium", "ml-dsa", "mldsa",
+    "falcon", "sphincs", "slh-dsa", "slhdsa",
+]
+
+TLS_GROUP_ALIASES = {
+    "x25519": "X25519",
+    "prime256v1": "ECDH-P-256",
+    "secp256r1": "ECDH-P-256",
+    "secp384r1": "ECDH-P-384",
+    "secp521r1": "ECDH-P-521",
+}
+
+RELATED_ASSET_TYPE_MAP = {
+    "algorithm": "algorithm",
+    "public-key": "publicKey",
+    "private-key": "privateKey",
+}
+
+MLKEM_NAME_PATTERN = re.compile(r"ml[-_ ]?kem[-_ ]?(\d+)", re.IGNORECASE)
+SHA_ALGO_PATTERN = re.compile(r"(?<![a-zA-Z\d])sha[-_ ]?\d+(?![a-zA-Z\d])", re.IGNORECASE)
 
 # ── TLS directive 파싱 패턴 (정적/컨테이너 분석 공용) ─────────────────────────
 TLS_DIRECTIVE_PATTERNS = {
@@ -79,15 +124,13 @@ TLS_DIRECTIVE_PATTERNS = {
 }
 
 
-# ── 유틸 ──────────────────────────────────────────────────────────────────────
+# ═══════════════════════════════════════════════════════════════════════════════
+# 유틸리티
+# ═══════════════════════════════════════════════════════════════════════════════
+
 def normalize_stage(stage: str) -> str:
-    """stage 인자를 정규화된 숫자 문자열로 변환.
-
-    CI 환경에서는 $GITHUB_ENV를 통해 STAGE 환경변수가 설정되므로,
-    --stage auto일 때 이를 자동으로 감지한다.
-    """
+    """stage 인자를 정규화된 숫자 문자열로 변환."""
     value = (stage or "auto").strip().lower()
-
     aliases = {
         "1": "1", "ecc": "1",
         "2": "2", "hybrid": "2",
@@ -95,7 +138,6 @@ def normalize_stage(stage: str) -> str:
         "auto": "auto",
     }
     result = aliases.get(value)
-
     if result is None:
         print(
             f"[WARN] 알 수 없는 stage 값 '{stage}' → auto로 대체합니다. "
@@ -103,26 +145,19 @@ def normalize_stage(stage: str) -> str:
             file=sys.stderr,
         )
         result = "auto"
-
-    # auto인 경우 CI 환경변수 $STAGE에서 자동 감지 시도
     if result == "auto":
         ci_stage = os.getenv("STAGE", "").strip()
         if ci_stage in ("1", "2", "3"):
             result = ci_stage
-
     return result
 
 
 def run_cmd(cmd: list, timeout: int = 30) -> dict:
     """외부 명령어를 실행하고 결과를 dict로 반환."""
     rendered_cmd = " ".join(shlex.quote(x) for x in cmd)
-
     try:
         proc = subprocess.run(
-            cmd,
-            capture_output=True,
-            encoding='utf-8',
-            timeout=timeout,
+            cmd, capture_output=True, encoding="utf-8", timeout=timeout,
         )
         return {
             "cmd": rendered_cmd,
@@ -130,7 +165,6 @@ def run_cmd(cmd: list, timeout: int = 30) -> dict:
             "stdout": proc.stdout or "",
             "stderr": proc.stderr or "",
         }
-
     except subprocess.TimeoutExpired as e:
         return {
             "cmd": rendered_cmd,
@@ -139,26 +173,22 @@ def run_cmd(cmd: list, timeout: int = 30) -> dict:
             "stderr": (e.stderr or b"").decode(errors="replace") if isinstance(e.stderr, bytes) else (e.stderr or ""),
             "error": "timeout",
         }
-
     except FileNotFoundError:
         return {
             "cmd": rendered_cmd,
             "returncode": 127,
-            "stdout": "",
-            "stderr": "",
+            "stdout": "", "stderr": "",
             "error": "command_not_found",
         }
 
 
 def resolve_config_path(stage: str, config_path: str) -> str:
-    """stage 기반으로 nginx 설정 파일 경로를 결정."""
     if config_path:
         return config_path
     return STAGE_CONFIG_MAP.get(stage, "nginx/nginx.conf")
 
 
 def split_directive_value(raw: str, mode: str) -> list:
-    """nginx 디렉티브 값을 파싱하여 리스트로 분리."""
     if mode == "colon_or_space":
         return [x.strip() for x in re.split(r"[:\s]+", raw) if x.strip()]
     if mode == "space":
@@ -167,30 +197,454 @@ def split_directive_value(raw: str, mode: str) -> list:
 
 
 def _parse_directives(config_text: str, patterns: dict) -> dict:
-    """설정 텍스트에서 정규식 패턴 딕셔너리에 해당하는 디렉티브를 추출하는 내부 헬퍼."""
     findings = {}
     for key, (pattern, mode) in patterns.items():
         m = re.search(pattern, config_text, re.MULTILINE)
         if not m:
             continue
         raw = m.group(1).strip()
-        if mode == "raw":
-            findings[key] = raw
-        else:
-            findings[key] = split_directive_value(raw, mode)
+        findings[key] = raw if mode == "raw" else split_directive_value(raw, mode)
     return findings
 
 
-# ── 정적 분석 ────────────────────────────────────────────────────────────────
-def static_analysis(config_path: str) -> dict:
-    """로컬 nginx 설정 파일을 파싱하여 TLS 관련 디렉티브를 추출."""
-    result = {
-        "method": "static",
-        "source": config_path,
-        "findings": {},
-        "notes": [],
-    }
+def iso_utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
+
+def slugify(value: str) -> str:
+    cleaned = re.sub(r"[^A-Za-z0-9._@+=-]+", "-", (value or "").strip())
+    return re.sub(r"-+", "-", cleaned).strip("-") or "unknown"
+
+
+def stable_redacted_suffix(value: str, length: int = 8) -> str:
+    raw = (value or "").encode("utf-8", errors="replace")
+    return hashlib.sha256(raw).hexdigest()[:length]
+
+
+def dedupe_keep_order(values: list) -> list:
+    seen = set()
+    return [x for x in (values or []) if x not in seen and not seen.add(x)]
+
+
+def parse_openssl_time(value: str) -> str | None:
+    if not value:
+        return None
+    normalized = re.sub(r"\s+", " ", value.strip())
+    for fmt in ("%b %d %H:%M:%S %Y %Z", "%b %d %H:%M:%S %Y GMT"):
+        try:
+            dt = datetime.strptime(normalized, fmt)
+            return dt.replace(tzinfo=timezone.utc).isoformat().replace("+00:00", "Z")
+        except ValueError:
+            continue
+    return None
+
+
+def prune_none(value):
+    if isinstance(value, dict):
+        return {
+            k: pruned for k, v in value.items()
+            if (pruned := prune_none(v)) is not None and pruned != {} and pruned != []
+        }
+    if isinstance(value, list):
+        return [
+            pruned for v in value
+            if (pruned := prune_none(v)) is not None and pruned != {} and pruned != []
+        ]
+    return value
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# CycloneDX 빌더 헬퍼
+# ═══════════════════════════════════════════════════════════════════════════════
+
+def make_property(name: str, value) -> dict | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        rendered = "true" if value else "false"
+    elif isinstance(value, (dict, list)):
+        rendered = json.dumps(value, ensure_ascii=False)
+    else:
+        rendered = str(value)
+    return {"name": name, "value": rendered}
+
+
+def append_properties(target: dict, *properties: dict | None):
+    props = [p for p in properties if p is not None]
+    if props:
+        target.setdefault("properties", []).extend(props)
+
+
+def add_component(components_by_ref: dict, component: dict):
+    component = prune_none(component)
+    ref = component.get("bom-ref")
+    if not ref:
+        raise ValueError("CycloneDX component에는 bom-ref가 필요합니다.")
+    existing = components_by_ref.get(ref)
+    if not existing:
+        components_by_ref[ref] = component
+        return
+    for key, value in component.items():
+        if key == "properties":
+            existing.setdefault("properties", []).extend(value)
+        elif key == "cryptoProperties":
+            existing.setdefault("cryptoProperties", {})
+            for ck, cv in value.items():
+                if isinstance(cv, list):
+                    existing["cryptoProperties"].setdefault(ck, []).extend(cv)
+                elif isinstance(cv, dict):
+                    existing["cryptoProperties"].setdefault(ck, {})
+                    for dk, dv in cv.items():
+                        if isinstance(dv, list):
+                            existing["cryptoProperties"][ck].setdefault(dk, []).extend(dv)
+                        else:
+                            existing["cryptoProperties"][ck].setdefault(dk, dv)
+                else:
+                    existing["cryptoProperties"].setdefault(ck, cv)
+        else:
+            existing.setdefault(key, value)
+
+
+def add_dependency(dependencies: list, ref: str, depends_on=None):
+    depends_on = dedupe_keep_order(depends_on or [])
+    if not depends_on:
+        return
+    for item in dependencies:
+        if item.get("ref") == ref:
+            item.setdefault("dependsOn", [])
+            item["dependsOn"] = dedupe_keep_order(item["dependsOn"] + depends_on)
+            return
+    dependencies.append({"ref": ref, "dependsOn": depends_on})
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# CycloneDX 컴포넌트 빌더
+# ═══════════════════════════════════════════════════════════════════════════════
+
+def protocol_version_only(raw: str) -> str | None:
+    if not raw:
+        return None
+    m = re.search(r"TLSv?(\d+(?:\.\d+)?)", raw, re.IGNORECASE)
+    return m.group(1) if m else None
+
+
+def protocol_name(raw: str, configured: list) -> str:
+    if raw:
+        return raw.strip()
+    return configured[0] if configured else "TLS"
+
+
+def make_related_asset(asset_type: str, ref: str) -> dict:
+    rendered_type = RELATED_ASSET_TYPE_MAP.get(asset_type, asset_type)
+    return {"type": rendered_type, "ref": ref}
+
+
+def dedupe_related_assets(assets: list[dict]) -> list[dict]:
+    seen = set()
+    result = []
+    for asset in assets or []:
+        key = (asset.get("type"), asset.get("ref"))
+        if key in seen:
+            continue
+        seen.add(key)
+        result.append(asset)
+    return result
+
+
+def decompose_key_exchange_name(name: str) -> dict:
+    raw = (name or "").strip()
+    lower = raw.lower().replace(" ", "")
+    if not raw:
+        return {"display_name": raw, "children": []}
+
+    mlkem = MLKEM_NAME_PATTERN.search(lower)
+    if mlkem:
+        children = []
+        if "x25519" in lower:
+            children.append("X25519")
+        else:
+            p_match = re.search(r"p[-_ ]?(\d+)", lower)
+            if p_match:
+                children.append(f"ECDH-P-{p_match.group(1)}")
+        children.append(f"ML-KEM-{mlkem.group(1)}")
+        return {"display_name": raw, "children": dedupe_keep_order(children)}
+
+    canonical = TLS_GROUP_ALIASES.get(lower)
+    if canonical:
+        return {"display_name": canonical, "children": [canonical]}
+
+    if re.fullmatch(r"x\d+", lower):
+        canonical = lower.upper()
+        return {"display_name": canonical, "children": [canonical]}
+
+    p_match = re.fullmatch(r"p[-_ ]?(\d+)", lower)
+    if p_match:
+        canonical = f"ECDH-P-{p_match.group(1)}"
+        return {"display_name": canonical, "children": [canonical]}
+
+    return {"display_name": raw, "children": [raw]}
+
+
+def extract_cipher_suite_algorithms(cipher_suite: str) -> list[str]:
+    suite = (cipher_suite or "").strip()
+    if not suite:
+        return []
+    upper = suite.upper().replace("-", "_")
+    algorithms = []
+
+    if "CHACHA20_POLY1305" in upper:
+        algorithms.append("ChaCha20-Poly1305")
+    aes_gcm = re.search(r"AES[_-]?(\d{3})[_-]?GCM", upper)
+    if aes_gcm:
+        algorithms.append(f"AES-{aes_gcm.group(1)}-GCM")
+    aes_ccm = re.search(r"AES[_-]?(\d{3})[_-]?CCM", upper)
+    if aes_ccm:
+        algorithms.append(f"AES-{aes_ccm.group(1)}-CCM")
+    sha_match = re.search(r"SHA[_-]?(\d{3})", upper)
+    if sha_match:
+        algorithms.append(f"SHA{sha_match.group(1)}")
+    if "ECDHE" in upper:
+        algorithms.append("ECDHE")
+    if re.search(r"(^|_)RSA(_|$)", upper):
+        algorithms.append("RSA")
+    if "ECDSA" in upper:
+        algorithms.append("ECDSA")
+
+    mlkem_match = MLKEM_NAME_PATTERN.search(upper)
+    if mlkem_match:
+        algorithms.append(f"ML-KEM-{mlkem_match.group(1)}")
+
+    # TODO: PQC TLS cipher suite naming이 최종 표준화되면 KEM/서명/대칭 구성요소 매핑을 확장한다.
+    return dedupe_keep_order(algorithms)
+
+
+def infer_algorithm_properties(name: str, context: str = "") -> dict:
+    lower = (name or "").lower()
+    props = {"executionEnvironment": "software-plain-ram", "implementationPlatform": "generic"}
+
+    mlkem_match = MLKEM_NAME_PATTERN.search(lower)
+    has_mlkem = bool(mlkem_match)
+    has_curve = (
+        "x25519" in lower
+        or "ecdh" in lower
+        or bool(re.search(r"p[-_ ]?(\d+)", lower))
+    )
+
+    if has_mlkem and has_curve:
+        props["primitive"] = "combiner"
+    elif has_mlkem:
+        props["primitive"] = "kem"
+    elif "x25519" in lower or "ecdh" in lower:
+        props["primitive"] = "key-agree"
+    elif any(t in lower for t in (
+        "rsa", "ecdsa", "ed25519", "ed448",
+        "dilithium", "ml-dsa", "falcon", "sphincs", "slh-dsa",
+    )):
+        props["primitive"] = "signature"
+    elif "aes" in lower or ("chacha20" in lower and "poly1305" in lower):
+        props["primitive"] = "aead"
+    elif SHA_ALGO_PATTERN.search(lower):
+        props["primitive"] = "digest"
+
+    if mlkem_match:
+        props["parameterSetIdentifier"] = mlkem_match.group(1)
+        props["algorithmFamily"] = "ML-KEM"
+    if not has_mlkem:
+        x_match = re.search(r"x(\d+)", lower)
+        if x_match:
+            props.setdefault("parameterSetIdentifier", x_match.group(1))
+    p_match = re.search(r"p[-_ ]?(\d+)", lower)
+    if p_match:
+        props["curve"] = f"P-{p_match.group(1)}"
+    rsa_match = re.search(r"rsa[^\d]*(\d{3,5})", lower)
+    if rsa_match:
+        props.setdefault("parameterSetIdentifier", rsa_match.group(1))
+        props.setdefault("algorithmFamily", "RSA")
+    if lower.startswith("ecdsa"):
+        props.setdefault("algorithmFamily", "ECDSA")
+    if "aes" in lower:
+        props.setdefault("algorithmFamily", "AES")
+    if "chacha20" in lower and "poly1305" in lower:
+        props.setdefault("algorithmFamily", "ChaCha20-Poly1305")
+    if SHA_ALGO_PATTERN.search(lower):
+        props.setdefault("algorithmFamily", "SHA")
+
+    if context == "certificate-signature":
+        props.setdefault("cryptoFunctions", ["sign", "verify"])
+    elif context == "key-exchange":
+        props.setdefault(
+            "cryptoFunctions",
+            ["encapsulate", "decapsulate"] if props.get("primitive") == "kem" else ["keygen", "keyderive"],
+        )
+    elif context == "public-key":
+        props.setdefault("cryptoFunctions", ["verify"])
+    elif context == "cipher-suite":
+        if props.get("primitive") == "aead":
+            props.setdefault("cryptoFunctions", ["encrypt", "decrypt"])
+        elif props.get("primitive") == "digest":
+            props.setdefault("cryptoFunctions", ["digest"])
+    return prune_none(props)
+
+
+def build_algorithm_component(name, context="", extra_properties=None):
+    ref = f"crypto/algorithm/{slugify(name)}"
+    comp = {
+        "bom-ref": ref, "type": "cryptographic-asset", "name": name,
+        "cryptoProperties": {"assetType": "algorithm",
+                             "algorithmProperties": infer_algorithm_properties(name, context)},
+    }
+    for p in extra_properties or []:
+        append_properties(comp, p)
+    return ref, prune_none(comp)
+
+
+def build_certificate_component(cert_f, cert_alg_ref, pk_ref, cert_path, *, redact=True):
+    if not cert_f:
+        return None, None
+    subject = cert_f.get("subject") or "server-certificate"
+    serial = cert_f.get("serial") or "unknown"
+    ref = f"crypto/certificate/{slugify(subject)}@{slugify(serial)}"
+    related = []
+    if cert_alg_ref:
+        related.append(make_related_asset("algorithm", cert_alg_ref))
+    if pk_ref:
+        related.append(make_related_asset("public-key", pk_ref))
+    comp = {
+        "bom-ref": ref, "type": "cryptographic-asset", "name": subject,
+        "cryptoProperties": {
+            "assetType": "certificate",
+            "certificateProperties": {
+                "serialNumber": cert_f.get("serial"),
+                "subjectName": subject,
+                "issuerName": cert_f.get("issuer"),
+                "notValidBefore": parse_openssl_time(cert_f.get("not_before")),
+                "notValidAfter": parse_openssl_time(cert_f.get("not_after")),
+                "certificateFormat": "X.509",
+                "certificateFileExtension": Path(cert_path).suffix.lstrip(".") if cert_path else None,
+                "relatedCryptographicAssets": {"assets": dedupe_related_assets(related)} if related else None,
+            },
+        },
+    }
+    append_properties(comp,
+                      make_property("securecapstone:cert:is_pqc", cert_f.get("is_pqc_certificate")),
+                      make_property("securecapstone:cert:pqc_note", cert_f.get("cert_pqc_note")),
+                      None if redact else make_property("securecapstone:cert:path", cert_path))
+    return ref, prune_none(comp)
+
+
+def build_public_key_component(cert_f, pk_alg_ref):
+    bits = cert_f.get("public_key_bits")
+    if not bits and not pk_alg_ref:
+        return None, None
+    name = cert_f.get("public_key_algorithm") or f"public-key-{bits or 'unknown'}"
+    ref = f"crypto/key/{slugify(name)}-{bits or 'unknown'}"
+    related = [make_related_asset("algorithm", pk_alg_ref)] if pk_alg_ref else []
+    comp = {
+        "bom-ref": ref, "type": "cryptographic-asset", "name": name,
+        "cryptoProperties": {
+            "assetType": "related-crypto-material",
+            "relatedCryptoMaterialProperties": {
+                "type": "public-key", "state": "active", "size": bits,
+                "relatedCryptographicAssets": {"assets": dedupe_related_assets(related)} if related else None,
+                "securedBy": {"mechanism": "Software"},
+            },
+        },
+    }
+    append_properties(comp, make_property("securecapstone:key:origin", "certificate-subject-public-key"))
+    return ref, prune_none(comp)
+
+
+def build_private_key_component(path, bits, pk_alg_ref, *, redact=True):
+    if not path:
+        return None, None
+    ref_slug = Path(path).name if redact else path
+    if redact:
+        ref = f"crypto/key/{slugify(ref_slug)}-{stable_redacted_suffix(path)}"
+    else:
+        ref = f"crypto/key/{slugify(ref_slug)}"
+    related = [make_related_asset("algorithm", pk_alg_ref)] if pk_alg_ref else []
+    comp = {
+        "bom-ref": ref, "type": "cryptographic-asset",
+        "name": Path(path).name if redact else path,
+        "cryptoProperties": {
+            "assetType": "related-crypto-material",
+            "relatedCryptoMaterialProperties": {
+                "type": "private-key", "state": "active", "size": bits,
+                "relatedCryptographicAssets": {"assets": dedupe_related_assets(related)} if related else None,
+                "securedBy": {"mechanism": "Software"},
+            },
+        },
+    }
+    append_properties(
+        comp,
+        make_property("securecapstone:key:size_inferred_from_certificate", bits is not None),
+        None if redact else make_property("securecapstone:key:path", path),
+    )
+    return ref, prune_none(comp)
+
+
+def build_protocol_component(
+    cfg_protos,
+    cfg_ciphers,
+    cfg_kex,
+    neg_proto,
+    neg_cipher,
+    neg_kex,
+    related_assets,
+    suite_algorithms=None,
+):
+    name = protocol_name(neg_proto, cfg_protos)
+    ref = f"crypto/protocol/{slugify(name)}"
+    suites = dedupe_keep_order(([neg_cipher] if neg_cipher else []) + (cfg_ciphers or []))
+    groups = dedupe_keep_order(([neg_kex] if neg_kex else []) + (cfg_kex or []))
+    suite_algorithms = suite_algorithms or {}
+
+    cipher_suites = []
+    for suite in suites:
+        entry = {"name": suite}
+        alg_refs = dedupe_keep_order(suite_algorithms.get(suite, []))
+        if alg_refs:
+            entry["algorithms"] = alg_refs
+        if neg_kex and neg_cipher and suite == neg_cipher:
+            entry["tlsGroups"] = [neg_kex]
+        elif not neg_cipher and len(groups) == 1:
+            entry["tlsGroups"] = groups
+        cipher_suites.append(entry)
+
+    comp = {
+        "bom-ref": ref, "type": "cryptographic-asset", "name": name,
+        "cryptoProperties": {
+            "assetType": "protocol",
+            "protocolProperties": {
+                "type": "tls", "version": protocol_version_only(name),
+                "cipherSuites": cipher_suites,
+                "relatedCryptographicAssets": {
+                    "assets": dedupe_related_assets(related_assets)
+                } if related_assets else None,
+            },
+        },
+    }
+    append_properties(comp,
+                      make_property("securecapstone:protocol:configured", cfg_protos),
+                      make_property("securecapstone:protocol:negotiated", neg_proto),
+                      make_property("securecapstone:protocol:configured_groups", cfg_kex),
+                      make_property("securecapstone:protocol:negotiated_group", neg_kex))
+    return ref, prune_none(comp)
+
+
+def extract_root_property(bom: dict, name: str):
+    for p in bom.get("properties", []):
+        if p.get("name") == name:
+            return p.get("value")
+    return None
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 정적 / 동적 분석
+# ═══════════════════════════════════════════════════════════════════════════════
+
+def static_analysis(config_path: str) -> dict:
+    result = {"method": "static", "source": config_path, "findings": {}, "notes": []}
     try:
         text = Path(config_path).read_text(encoding="utf-8")
     except FileNotFoundError:
@@ -200,9 +654,13 @@ def static_analysis(config_path: str) -> dict:
         result["error"] = f"{config_path} 읽기 실패: {e}"
         return result
 
-    result["findings"] = _parse_directives(text, TLS_DIRECTIVE_PATTERNS)
+    result["findings"] = parse_nginx_directives(text)
 
-    # TLS 1.3 전용 설정에서 ssl_ciphers가 없는 건 정상
+    if re.search(r"^\s*include\s+", text, re.MULTILINE):
+        result["notes"].append(
+            "로컬 nginx 설정에 include가 있어 단일 파일 정적 분석만으로는 실제 적용값과 다를 수 있습니다."
+        )
+
     protocols = result["findings"].get("ssl_protocols", [])
     if "ssl_ciphers" not in result["findings"]:
         if protocols == ["TLSv1.3"]:
@@ -216,102 +674,105 @@ def static_analysis(config_path: str) -> dict:
                 "ssl_ciphers가 명시되지 않았습니다. "
                 "TLS 1.2 이하 프로토콜이 포함된 경우 기본 cipher에 의존하게 되므로 주의가 필요합니다."
             )
-
     if not result["notes"]:
         del result["notes"]
-
     return result
 
 
-# ── 컨테이너 내 설정 읽기 (보조) ──────────────────────────────────────────────
-def read_container_config(
-    server_container: str,
-    config_path: str = "/opt/nginx/nginx-conf/nginx.conf",
-) -> dict:
-    """서버 컨테이너 내부에서 실행 중인 실제 nginx.conf를 읽어온다.
+def read_container_config(server_container, config_path="/opt/nginx/nginx-conf/nginx.conf"):
+    dump_cmd = ["docker", "exec", server_container, "nginx", "-T"]
+    dump = run_cmd(dump_cmd, timeout=15)
+    dump_text = dump.get("stdout") or ""
+    if dump.get("stderr"):
+        dump_text += ("\n" if dump_text else "") + dump["stderr"]
+    if dump["returncode"] == 0 and dump_text.strip():
+        return {"config_text": dump_text, "source": "nginx -T"}
 
-    CI에서 nginx.conf가 cp로 교체되므로 로컬 파일과 실제 실행 설정이 다를 수 있다.
-    """
     cmd = ["docker", "exec", server_container, "cat", config_path]
-    result = run_cmd(cmd, timeout=10)
+    r = run_cmd(cmd, timeout=10)
+    if r.get("error") or r["returncode"] != 0:
+        return {"error": f"컨테이너 설정 읽기 실패: {(r.get('stderr') or r.get('stdout') or dump.get('stderr') or dump.get('stdout') or '').strip()}"}
+    return {"config_text": r["stdout"], "source": config_path}
 
-    if result.get("error") or result["returncode"] != 0:
-        err = (result.get("stderr") or result.get("stdout") or "").strip()
-        return {"error": f"컨테이너 설정 읽기 실패: {err}"}
 
-    return {"config_text": result["stdout"]}
+def strip_nginx_comments(config_text: str) -> str:
+    lines = []
+    for line in config_text.splitlines():
+        in_single = False
+        in_double = False
+        escaped = False
+        rendered = []
+        for ch in line:
+            if escaped:
+                rendered.append(ch)
+                escaped = False
+                continue
+            if ch == "\\":
+                rendered.append(ch)
+                escaped = True
+                continue
+            if ch == '"' and not in_single:
+                in_double = not in_double
+                rendered.append(ch)
+                continue
+            if ch == "'" and not in_double:
+                in_single = not in_single
+                rendered.append(ch)
+                continue
+            if ch == "#" and not in_single and not in_double:
+                break
+            rendered.append(ch)
+        lines.append("".join(rendered).rstrip())
+    return "\n".join(lines)
 
 
 def parse_nginx_directives(config_text: str) -> dict:
-    """컨테이너 내부 nginx 설정 문자열에서 핵심 TLS directive를 추출."""
-    return _parse_directives(config_text, TLS_DIRECTIVE_PATTERNS)
+    normalized = strip_nginx_comments(config_text)
+    findings = {}
+    for key, (pattern, mode) in TLS_DIRECTIVE_PATTERNS.items():
+        matches = [m.group(1).strip() for m in re.finditer(pattern, normalized, re.MULTILINE)]
+        if not matches:
+            continue
+        if mode == "raw":
+            findings[key] = matches[-1]
+        else:
+            values = []
+            for raw in matches:
+                values.extend(split_directive_value(raw, mode))
+            findings[key] = dedupe_keep_order(values)
+    return findings
 
 
-# ── 단계 판정 ────────────────────────────────────────────────────────────────
 def classify_stage(key_group: str) -> str:
-    """협상된 키 교환 그룹을 기반으로 PQC 단계를 판정.
-
-    판정 우선순위:
-    1. X25519 + MLKEM -> STAGE_2_HYBRID_PQC  (예: X25519MLKEM768)
-    2. P-curve + MLKEM 또는 순수 MLKEM -> STAGE_3_POST_QUANTUM  (예: p521_mlkem1024)
-    3. 그 외 값 있음 -> STAGE_1_CLASSICAL
-    4. 값 없음 -> UNKNOWN
-    """
     g = (key_group or "").strip()
     if not g:
         return "UNKNOWN"
-
-    # Stage 2 먼저 체크 (X25519 + MLKEM 조합)
-    for pattern in HYBRID_PQC_PATTERNS:
-        if pattern.search(g):
+    for p in HYBRID_PQC_PATTERNS:
+        if p.search(g):
             return "STAGE_2_HYBRID_PQC"
-
-    # Stage 3 체크 (P-curve + MLKEM, 또는 순수 MLKEM)
-    for pattern in PURE_PQC_PATTERNS:
-        if pattern.search(g):
+    for p in PURE_PQC_PATTERNS:
+        if p.search(g):
             return "STAGE_3_POST_QUANTUM"
-
     return "STAGE_1_CLASSICAL"
 
 
-# ── verify_tls.sh 출력 파싱 ──────────────────────────────────────────────────
 def parse_verify_tls_output(output: str) -> dict:
-    """verify_tls.sh의 출력을 파싱.
+    """verify_tls.sh / tls_check.sh 출력을 파싱.
 
-    tester/verify_tls.sh (curl 기반) 출력 형식:
-        Protocol : TLSv1.3
-        Cipher   : TLS_AES_256_GCM_SHA384
-        Key Group: X25519MLKEM768
-        판정: Stage 2 - Hybrid PQC-TLS
-
-    pqc-webserver/scripts/verify_tls.sh (openssl s_client 기반) 출력 형식:
-        Protocol version: TLSv1.3
-        Ciphersuite: TLS_AES_256_GCM_SHA384
-        Negotiated TLS1.3 group: X25519MLKEM768
-        판정: Stage 2 - Hybrid PQC-TLS
-
-    주의: Stage 3에서는 "판정:" 라인이 2개 출력되므로 (PQC 연결 확인 + 최종 판정)
-    마지막 매칭을 사용한다.
+    주의: Stage 3에서는 "판정:" 라인이 2개 출력되므로 마지막 매칭을 사용한다.
     """
     result = {}
-
-    # 두 가지 스크립트 형식을 모두 커버하는 패턴 (우선순위 순)
-    # "판정"을 제외한 패턴은 first-match 사용
     first_match_patterns = [
-        # --- 프로토콜 ---
         (r"Protocol\s*(?:version)?\s*:\s*(.+)", "negotiated_protocol"),
-        # --- 암호 스위트 ---
         (r"Cipher(?:suite)?\s*:\s*(.+)", "negotiated_cipher"),
-        # --- 키 교환 그룹 ---
         (r"Key Group\s*:\s*(.+)", "key_exchange_actual"),
         (r"^Group\s*:\s*(.+)", "key_exchange_actual"),
         (r"Negotiated TLS[\d.]+ group\s*:\s*(.+)", "key_exchange_actual"),
         (r"Server Temp Key\s*:\s*(.+)", "key_exchange_actual"),
         (r"Peer Temp Key\s*:\s*(.+)", "key_exchange_actual"),
     ]
-
     for pattern, key in first_match_patterns:
-        m = re.search(pattern, output, re.IGNORECASE)
+        m = re.search(pattern, output, re.IGNORECASE | re.MULTILINE)
         if m and key not in result:
             val = m.group(1).strip()
             if val.lower() != "unknown":
@@ -320,14 +781,14 @@ def parse_verify_tls_output(output: str) -> dict:
     # "판정:" 패턴은 마지막 매칭을 사용 (Stage 3에서 최종 판정 라인 캡처)
     judgement_matches = re.findall(r"판정\s*:\s*(.+)", output)
     if judgement_matches:
-        final_judgement = judgement_matches[-1].strip()
-        if final_judgement.lower() != "unknown":
-            result["verify_tls_judgement"] = final_judgement
+        final = judgement_matches[-1].strip()
+        if final.lower() != "unknown":
+            result["verify_tls_judgement"] = final
 
     # tls_check.sh 형식: "[PASS] Stage 2 policy satisfied." / "[FAIL] ..."
     if "verify_tls_judgement" not in result:
-        if re.search(r"\[PASS\].*Stage\s*(\d+)", output):
-            m = re.search(r"\[PASS\].*Stage\s*(\d+)", output)
+        m = re.search(r"\[PASS\].*Stage\s*(\d+)", output)
+        if m:
             result["verify_tls_judgement"] = f"Stage {m.group(1)} - policy satisfied"
         elif re.search(r"\[FAIL\]", output):
             result["verify_tls_judgement"] = "fail"
@@ -335,17 +796,8 @@ def parse_verify_tls_output(output: str) -> dict:
     return result
 
 
-# ── 인증서 정보 파싱 ──────────────────────────────────────────────────────────
-PQC_CERT_ALGORITHMS = [
-    "dilithium", "ml-dsa", "mldsa",
-    "falcon", "sphincs", "slh-dsa", "slhdsa",
-]
-
-
 def parse_cert_info(cert_text: str) -> dict:
-    """openssl x509 -text 출력에서 인증서 정보를 추출."""
     result = {}
-
     for pattern, key in [
         (r"subject\s*=\s*([^\n]+)", "subject"),
         (r"issuer\s*=\s*([^\n]+)", "issuer"),
@@ -356,52 +808,38 @@ def parse_cert_info(cert_text: str) -> dict:
         m = re.search(pattern, cert_text)
         if m:
             result[key] = m.group(1).strip()
-
     m = re.search(r"Signature Algorithm:\s*([^\n]+)", cert_text)
     if m:
         result["cert_signature_algorithm"] = m.group(1).strip()
-
     m = re.search(r"Public-Key:\s*\((\d+)\s*bit\)", cert_text)
     if m:
         result["public_key_bits"] = int(m.group(1))
-
     m = re.search(r"Public Key Algorithm:\s*([^\n]+)", cert_text)
     if m:
         result["public_key_algorithm"] = m.group(1).strip()
 
-    # 인증서가 PQC 알고리즘인지 판정
     sig_alg = result.get("cert_signature_algorithm", "").lower()
     pk_alg = result.get("public_key_algorithm", "").lower()
-    combined_alg = f"{sig_alg} {pk_alg}"
-
-    is_pqc_cert = any(pqc in combined_alg for pqc in PQC_CERT_ALGORITHMS)
-    result["is_pqc_certificate"] = is_pqc_cert
-
-    if not is_pqc_cert:
+    is_pqc = any(pqc in f"{sig_alg} {pk_alg}" for pqc in PQC_CERT_ALGORITHMS)
+    result["is_pqc_certificate"] = is_pqc
+    if not is_pqc:
         result["cert_pqc_note"] = (
             "인증서 서명/공개키가 전통적 알고리즘(RSA/ECDSA)입니다. "
-            "TLS 키 교환이 PQC라도 인증서 자체는 양자 내성이 아닙니다."
-        )
-
+            "TLS 키 교환이 PQC라도 인증서 자체는 양자 내성이 아닙니다.")
     return result
 
 
-# ── 교차 검증 ────────────────────────────────────────────────────────────────
-def cross_validate(our_status: str, script_judgement: str, requested_stage: str) -> dict:
-    """cbom_gen의 classify_stage() 결과와 verify_tls.sh의 판정을 교차 검증."""
+def cross_validate(our_status, script_judgement, requested_stage, *, strict=False):
+    """교차 검증. strict=True이면 판정 파싱 실패 시에도 consistent=False."""
     validation = {"consistent": True, "warnings": []}
-
     if not script_judgement:
-        validation["warnings"].append("verify_tls.sh 판정 결과를 파싱하지 못했습니다.")
+        validation["warnings"].append("검증 스크립트 판정 결과를 파싱하지 못했습니다.")
+        if strict:
+            validation["consistent"] = False
+            validation["warnings"].append("엄격 모드: 판정 결과를 확인할 수 없으므로 검증 실패로 처리합니다.")
         return validation
 
     jl = script_judgement.lower()
-
-    # verify_tls.sh 판정 -> stage 숫자
-    # Stage 3 최종 판정 형식: "Stage 3 - PQC 강제 적용 ✓ ..."
-    # Stage 2 판정 형식:      "Stage 2 - Hybrid PQC-TLS ✓"
-    # Stage 1 판정 형식:      "Stage 1 - Classical TLS (ECC) ..."
-    # PQC 키워드 기반 fallback: "pqc" 포함 시 Stage 3로 추정
     if "stage 3" in jl:
         script_stage = "3"
     elif "stage 2" in jl:
@@ -409,222 +847,155 @@ def cross_validate(our_status: str, script_judgement: str, requested_stage: str)
     elif "stage 1" in jl:
         script_stage = "1"
     elif "pqc" in jl and "hybrid" not in jl:
-        # fallback: "PQC 강제 적용" 등 stage 번호 없이 PQC만 언급된 경우
         script_stage = "3"
     else:
         script_stage = None
 
-    # cbom_gen classify_stage 결과 -> stage 숫자
-    our_stage_map = {
-        "STAGE_1_CLASSICAL": "1",
-        "STAGE_2_HYBRID_PQC": "2",
-        "STAGE_3_POST_QUANTUM": "3",
-    }
-    our_stage = our_stage_map.get(our_status)
+    our_stage = {"STAGE_1_CLASSICAL": "1", "STAGE_2_HYBRID_PQC": "2", "STAGE_3_POST_QUANTUM": "3"}.get(our_status)
 
-    # 두 판정이 불일치하는 경우
     if script_stage and our_stage and script_stage != our_stage:
         validation["consistent"] = False
         validation["warnings"].append(
-            f"판정 불일치: verify_tls.sh는 Stage {script_stage}, "
-            f"cbom_gen은 {our_status}으로 판정했습니다. "
-            "파싱 로직 또는 알고리즘 매핑을 확인하세요."
-        )
-
-    # 요청한 stage와 실제 협상 결과가 다른 경우 — 서버 설정 미적용 가능성
+            f"판정 불일치: 검증 스크립트는 Stage {script_stage}, cbom_gen은 {our_status}으로 판정했습니다. "
+            "파싱 로직 또는 알고리즘 매핑을 확인하세요.")
     if requested_stage in ("1", "2", "3") and our_stage and requested_stage != our_stage:
         validation["consistent"] = False
         validation["warnings"].append(
             f"요청 Stage({requested_stage})와 실제 협상 결과(Stage {our_stage})가 다릅니다. "
-            "서버 설정이 올바르게 적용되었는지 확인하세요."
-        )
-
+            "서버 설정이 올바르게 적용되었는지 확인하세요.")
     if not validation["warnings"]:
         del validation["warnings"]
-
     return validation
 
 
-# ── 동적 분석 ────────────────────────────────────────────────────────────────
-def dynamic_analysis(
-    host: str,
-    port: int,
-    tester_container: str,
-    server_container: str,
-    server_cert_path: str,
-    stage: str,
-    verify_script: str,
-) -> dict:
-    """docker exec으로 TLS 핸드셰이크 검증 및 인증서 정보를 수집."""
-    result = {
-        "method": "dynamic",
-        "target": f"{host}:{port}",
-        "tester": tester_container,
-        "server": server_container,
-        "findings": {},
-    }
+def dynamic_analysis(host, port, tester_container, server_container, server_cert_path, stage, verify_script):
+    """docker exec으로 TLS 핸드셰이크 검증 및 인증서 정보를 수집.
 
-    # ── verify_tls.sh 실행 ──
-    verify_cmd = [
-        "docker", "exec", tester_container,
-        verify_script,
-        host, str(port), stage,
-    ]
+    verify 스크립트가 실패(non-zero exit)하면 error를 그대로 유지한다.
+    부분 파싱은 참고용으로만 보존.
+    """
+    result = {
+        "method": "dynamic", "target": f"{host}:{port}",
+        "tester": tester_container, "server": server_container, "findings": {},
+    }
+    verify_cmd = ["docker", "exec", tester_container, verify_script, host, str(port), stage]
     verify = run_cmd(verify_cmd, timeout=30)
     result["verify_command"] = verify["cmd"]
+    result["verify_exit_code"] = verify["returncode"]
 
     if verify.get("error") == "command_not_found":
-        result["error"] = "docker 또는 verify_tls.sh 명령어를 찾을 수 없습니다"
+        result["error"] = "docker 또는 검증 스크립트 명령어를 찾을 수 없습니다"
         result["findings"]["raw_output"] = verify["stdout"] + verify["stderr"]
         return result
 
-    combined_output = verify["stdout"]
+    combined = verify["stdout"]
     if verify["stdout"] and verify["stderr"]:
-        combined_output += "\n"
-    combined_output += verify["stderr"]
-    result["findings"]["raw_output"] = combined_output
+        combined += "\n"
+    combined += verify["stderr"]
+    result["findings"]["raw_output"] = combined
 
     if verify.get("error") == "timeout":
         result["error"] = "TLS 검증 타임아웃 (30초 초과)"
     elif verify["returncode"] != 0:
         result["error"] = f"TLS 검증 실패 (exit code: {verify['returncode']})"
 
-    # exit code와 무관하게 가능한 정보는 최대한 파싱
-    parsed = parse_verify_tls_output(combined_output)
+    parsed = parse_verify_tls_output(combined)
     result["findings"].update(parsed)
-
-    # 파싱에 성공한 경우 치명 오류 대신 warning 성격으로 완화
-    if result.get("error") and result["findings"].get("negotiated_protocol"):
-        result["warning"] = result.pop("error")
+    # error→warning 강등 없음: 검증 실패는 실패다
 
     # ── 인증서 정보 수집 ──
-    # verify_tls.sh가 non-zero여도 서버 컨테이너에서 cert 정보는 여전히 수집 가능하므로 계속 진행.
     cert_cmd = [
-        "docker", "exec", server_container,
-        "openssl", "x509",
-        "-in", server_cert_path,
-        "-noout", "-subject", "-issuer", "-serial", "-dates", "-text",
+        "docker", "exec", server_container, "openssl", "x509",
+        "-in", server_cert_path, "-noout", "-subject", "-issuer", "-serial", "-dates", "-text",
     ]
     cert = run_cmd(cert_cmd, timeout=15)
     result["cert_command"] = cert["cmd"]
-
     if cert.get("error") == "command_not_found":
         result["cert_error"] = "docker 또는 openssl 명령어를 찾을 수 없습니다"
     elif cert.get("error") == "timeout":
         result["cert_error"] = "인증서 정보 조회 타임아웃"
     elif cert["returncode"] == 0:
-        cert_text = cert["stdout"]
+        ct = cert["stdout"]
         if cert["stdout"] and cert["stderr"]:
-            cert_text += "\n"
-        cert_text += cert["stderr"]
-        result["findings"]["certificate"] = parse_cert_info(cert_text)
+            ct += "\n"
+        ct += cert["stderr"]
+        result["findings"]["certificate"] = parse_cert_info(ct)
     else:
         result["cert_error"] = (cert["stderr"] or cert["stdout"]).strip()
-
     return result
 
 
-# ── CBOM 생성 ─────────────────────────────────────────────────────────────────
-def generate_cbom(
-    host: str = DEFAULT_HOST,
-    port: int = DEFAULT_PORT,
-    stage: str = "auto",
-    config_path: str = "",
-    tester_container: str = DEFAULT_TESTER,
-    server_container: str = DEFAULT_SERVER,
-    server_cert_path: str = DEFAULT_CERT_PATH,
-    verify_script: str = DEFAULT_VERIFY_SCRIPT,
-) -> dict:
-    """정적 분석 + 동적 분석 결과를 결합하여 CBOM JSON을 생성."""
+# ═══════════════════════════════════════════════════════════════════════════════
+# 스냅샷 → CycloneDX 변환
+# ═══════════════════════════════════════════════════════════════════════════════
 
+def build_analysis_snapshot(
+    host=DEFAULT_HOST, port=DEFAULT_PORT, stage="auto", config_path="",
+    tester_container=DEFAULT_TESTER, server_container=DEFAULT_SERVER,
+    server_cert_path=DEFAULT_CERT_PATH, verify_script=DEFAULT_VERIFY_SCRIPT,
+    strict=False,
+):
     normalized_stage = normalize_stage(stage)
     resolved_config = resolve_config_path(normalized_stage, config_path)
 
-    # ── 정적 분석 (로컬 nginx 설정 파일) ──
     static = static_analysis(resolved_config)
 
-    # ── 컨테이너 실행 설정 보조 확인 ──
-    # CI에서 cp로 nginx.conf가 교체되므로 로컬 파일과 컨테이너 내부 설정이 다를 수 있음
     container_conf = read_container_config(server_container)
-
-    # 컨테이너 설정 파싱 결과 캐시 (중복 호출 방지)
     container_findings = None
     if "config_text" in container_conf:
         static["container_config_available"] = True
         container_findings = parse_nginx_directives(container_conf["config_text"])
         local_findings = static.get("findings", {})
         for key in ("ssl_protocols", "ssl_ciphers", "ssl_ecdh_curve", "ssl_certificate", "ssl_certificate_key"):
-            local_val = local_findings.get(key)
-            container_val = container_findings.get(key)
-            if local_val is not None and container_val is not None and local_val != container_val:
+            lv, cv = local_findings.get(key), container_findings.get(key)
+            if lv is not None and cv is not None and lv != cv:
                 static.setdefault("notes", []).append(
-                    f"로컬 설정의 {key}({local_val})와 컨테이너 내부 설정({container_val})이 다릅니다. "
-                    "CI에서 nginx.conf가 교체되었을 수 있습니다."
-                )
+                    f"로컬 설정의 {key}({lv})와 컨테이너 내부 설정({cv})이 다릅니다. "
+                    "CI에서 nginx.conf가 교체되었을 수 있습니다.")
     else:
         static["container_config_available"] = False
 
-    # ── 동적 분석 (TLS 핸드셰이크 + 인증서) ──
     dynamic = dynamic_analysis(
-        host=host,
-        port=port,
-        tester_container=tester_container,
-        server_container=server_container,
-        server_cert_path=server_cert_path,
-        stage=normalized_stage,
-        verify_script=verify_script,
-    )
+        host, port, tester_container, server_container, server_cert_path, normalized_stage, verify_script)
 
     static_f = static.get("findings", {})
     dynamic_f = dynamic.get("findings", {})
     cert_f = dynamic_f.get("certificate", {})
 
     # effective_static: 컨테이너 설정이 있으면 우선 적용
-    effective_static = dict(static_f)
+    effective = dict(static_f)
     if container_findings is not None:
-        static["effective_findings"] = container_findings
-        static["effective_source"] = f"container:{server_container}:/opt/nginx/nginx-conf/nginx.conf"
         for key in ("ssl_protocols", "ssl_ciphers", "ssl_ecdh_curve", "ssl_certificate", "ssl_certificate_key"):
             if container_findings.get(key) is not None:
-                effective_static[key] = container_findings[key]
-    else:
-        static["effective_findings"] = static_f
-        static["effective_source"] = resolved_config
+                effective[key] = container_findings[key]
 
-    # ── PQC 상태 판정 ──
     key_exchange = dynamic_f.get("key_exchange_actual", "")
-    if dynamic.get("error") and not dynamic_f.get("negotiated_protocol"):
+    if dynamic.get("error"):
         pqc_status = "DYNAMIC_ANALYSIS_FAILED"
+        partial = classify_stage(key_exchange) if key_exchange else None
     else:
         pqc_status = classify_stage(key_exchange)
+        partial = None
 
-    # ── 교차 검증 ──
     validation = cross_validate(
-        our_status=pqc_status,
+        our_status=pqc_status if pqc_status != "DYNAMIC_ANALYSIS_FAILED" else (partial or pqc_status),
         script_judgement=dynamic_f.get("verify_tls_judgement", ""),
         requested_stage=normalized_stage,
+        strict=strict,
     )
 
-    # ── CBOM 조립 ──
-    cbom = {
-        "cbom_version": "1.1",
-        "generated_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
-        "generator": "cbom_gen.py",
-        "target": {
-            "host": host,
-            "port": port,
-            "stage_requested": normalized_stage,
-            "scope": "TLS Termination",
-        },
+    snapshot = {
+        "generated_at": iso_utc_now(),
+        "generator": GENERATOR_NAME,
+        "target": {"host": host, "port": port, "stage_requested": normalized_stage, "scope": "TLS Termination"},
         "pqc_status": pqc_status,
         "validation": validation,
         "crypto_assets": {
-            "configured_protocols": effective_static.get("ssl_protocols", []),
-            "configured_ciphers": effective_static.get("ssl_ciphers", static_f.get("ssl_ciphers", [])),
-            "configured_key_exchange": effective_static.get("ssl_ecdh_curve", []),
-            "certificate_path": effective_static.get("ssl_certificate"),
-            "private_key_path": effective_static.get("ssl_certificate_key"),
-            "config_evidence_source": static.get("effective_source"),
+            "configured_protocols": effective.get("ssl_protocols", []),
+            "configured_ciphers": effective.get("ssl_ciphers", static_f.get("ssl_ciphers", [])),
+            "configured_key_exchange": effective.get("ssl_ecdh_curve", []),
+            "certificate_path": effective.get("ssl_certificate"),
+            "private_key_path": effective.get("ssl_certificate_key"),
             "negotiated_protocol": dynamic_f.get("negotiated_protocol"),
             "negotiated_cipher": dynamic_f.get("negotiated_cipher"),
             "negotiated_key_exchange": dynamic_f.get("key_exchange_actual"),
@@ -638,73 +1009,235 @@ def generate_cbom(
             "certificate_not_before": cert_f.get("not_before"),
             "certificate_not_after": cert_f.get("not_after"),
         },
-        "analysis_detail": {
-            "static": static,
-            "dynamic": dynamic,
+        "analysis_detail": {"static": static, "dynamic": dynamic},
+    }
+    if partial:
+        snapshot["partial_classification"] = partial
+    return snapshot
+
+
+def convert_snapshot_to_cyclonedx(snapshot, spec_version=DEFAULT_SPEC_VERSION, *, redact=True):
+    ca = snapshot.get("crypto_assets", {})
+    ad = snapshot.get("analysis_detail", {})
+    static, dynamic = ad.get("static", {}), ad.get("dynamic", {})
+    cert_f = dynamic.get("findings", {}).get("certificate", {})
+
+    cfg_protos = dedupe_keep_order(ca.get("configured_protocols", []))
+    cfg_ciphers = dedupe_keep_order(ca.get("configured_ciphers", []))
+    cfg_kex = dedupe_keep_order(ca.get("configured_key_exchange", []))
+    neg_proto = ca.get("negotiated_protocol")
+    neg_cipher = ca.get("negotiated_cipher")
+    neg_kex = ca.get("negotiated_key_exchange")
+
+    host = snapshot.get("target", {}).get("host", DEFAULT_HOST)
+    port = snapshot.get("target", {}).get("port", DEFAULT_PORT)
+    stage_req = snapshot.get("target", {}).get("stage_requested")
+    pqc_status = snapshot.get("pqc_status")
+    validation = snapshot.get("validation", {})
+
+    root_ref = f"target/tls-termination/{slugify(host)}:{port}"
+    root_comp = {
+        "bom-ref": root_ref, "type": "application",
+        "name": f"TLS Termination Endpoint ({host}:{port})",
+        "version": f"stage-{stage_req}" if stage_req else None,
+        "description": "Observed TLS termination configuration and runtime cryptographic assets.",
+    }
+    append_properties(root_comp,
+                      make_property("securecapstone:scope", snapshot.get("target", {}).get("scope")),
+                      make_property("securecapstone:host", host),
+                      make_property("securecapstone:port", port))
+
+    comps, deps = {}, []
+    root_refs = []
+    proto_related_assets = []
+    suite_algorithms = {}
+
+    def register_component(ref, comp, *, root=False, related_type=None):
+        if not ref or not comp:
+            return
+        add_component(comps, comp)
+        if root:
+            root_refs.append(ref)
+        if related_type:
+            proto_related_assets.append(make_related_asset(related_type, ref))
+
+    for name, source in [(n, "configured") for n in cfg_kex] + ([(neg_kex, "negotiated")] if neg_kex else []):
+        parsed = decompose_key_exchange_name(name)
+        child_refs = []
+        for child_name in parsed["children"]:
+            child_ref, child_comp = build_algorithm_component(
+                child_name,
+                "key-exchange",
+                [
+                    make_property("securecapstone:source", source),
+                    make_property("securecapstone:key_exchange:group", name),
+                ],
+            )
+            register_component(child_ref, child_comp, root=True, related_type="algorithm")
+            child_refs.append(child_ref)
+
+        display_name = parsed["display_name"] or name
+        child_unique = dedupe_keep_order(parsed["children"])
+        is_composite = len(child_unique) > 1 or display_name != (child_unique[0] if child_unique else display_name)
+        if is_composite:
+            group_ref, group_comp = build_algorithm_component(
+                display_name,
+                "key-exchange",
+                [
+                    make_property("securecapstone:source", source),
+                    make_property("securecapstone:key_exchange:group", name),
+                    make_property("securecapstone:key_exchange:decomposed", child_unique),
+                ],
+            )
+            register_component(group_ref, group_comp, root=True, related_type="algorithm")
+            if child_refs:
+                add_dependency(deps, group_ref, child_refs)
+
+    cert_sig_ref = None
+    if ca.get("cert_signature_algorithm"):
+        cert_sig_ref, c = build_algorithm_component(ca["cert_signature_algorithm"], "certificate-signature")
+        register_component(cert_sig_ref, c, root=True, related_type="algorithm")
+
+    pk_alg_ref = None
+    if ca.get("cert_public_key_algorithm"):
+        pk_alg_ref, c = build_algorithm_component(ca["cert_public_key_algorithm"], "public-key")
+        register_component(pk_alg_ref, c, root=True, related_type="algorithm")
+
+    pk_ref, pk_c = build_public_key_component(cert_f, pk_alg_ref)
+    if pk_c:
+        register_component(pk_ref, pk_c, root=True, related_type="public-key")
+        if pk_alg_ref:
+            add_dependency(deps, pk_ref, [pk_alg_ref])
+
+    sk_ref, sk_c = build_private_key_component(ca.get("private_key_path"), ca.get("cert_public_key_bits"), pk_alg_ref, redact=redact)
+    if sk_c:
+        register_component(sk_ref, sk_c, root=True, related_type="private-key")
+        if pk_alg_ref:
+            add_dependency(deps, sk_ref, [pk_alg_ref])
+
+    cert_ref, cert_c = build_certificate_component(cert_f, cert_sig_ref, pk_ref, ca.get("certificate_path"), redact=redact)
+    if cert_c:
+        register_component(cert_ref, cert_c, root=True)
+        cd = [r for r in (cert_sig_ref, pk_ref) if r]
+        if cd:
+            add_dependency(deps, cert_ref, cd)
+
+    for suite in dedupe_keep_order(([neg_cipher] if neg_cipher else []) + cfg_ciphers):
+        alg_refs = []
+        for alg_name in extract_cipher_suite_algorithms(suite):
+            alg_ref, alg_comp = build_algorithm_component(
+                alg_name,
+                "cipher-suite",
+                [make_property("securecapstone:cipher_suite", suite)],
+            )
+            register_component(alg_ref, alg_comp, root=True, related_type="algorithm")
+            alg_refs.append(alg_ref)
+        if alg_refs:
+            suite_algorithms[suite] = dedupe_keep_order(alg_refs)
+
+    p_ref, p_c = build_protocol_component(
+        cfg_protos,
+        cfg_ciphers,
+        cfg_kex,
+        neg_proto,
+        neg_cipher,
+        neg_kex,
+        proto_related_assets,
+        suite_algorithms=suite_algorithms,
+    )
+    register_component(p_ref, p_c, root=True)
+    add_dependency(deps, p_ref, [asset["ref"] for asset in dedupe_related_assets(proto_related_assets)])
+    if cert_ref:
+        add_dependency(deps, p_ref, [cert_ref])
+    add_dependency(deps, root_ref, dedupe_keep_order(root_refs + ([cert_ref] if cert_ref else [])))
+
+    bom_props = [
+        make_property("securecapstone:generator", snapshot.get("generator")),
+        make_property("securecapstone:scope", snapshot.get("target", {}).get("scope")),
+        make_property("securecapstone:stage_requested", stage_req),
+        make_property("securecapstone:pqc_status", pqc_status),
+        make_property("securecapstone:validation", validation),
+    ]
+    if snapshot.get("partial_classification"):
+        bom_props.append(make_property("securecapstone:partial_classification", snapshot["partial_classification"]))
+    if not redact:
+        bom_props.extend([
+            make_property("securecapstone:analysis_detail:static", static),
+            make_property("securecapstone:analysis_detail:dynamic", dynamic),
+        ])
+    if isinstance(static, dict) and static.get("notes"):
+        bom_props.append(make_property("securecapstone:notes:static", static["notes"]))
+    if isinstance(dynamic, dict) and dynamic.get("error"):
+        bom_props.append(make_property("securecapstone:error:dynamic", dynamic["error"]))
+
+    return prune_none({
+        "$schema": CYCLONEDX_SCHEMA_MAP.get(spec_version, f"https://cyclonedx.org/schema/bom-{spec_version}.schema.json"),
+        "bomFormat": "CycloneDX", "specVersion": spec_version,
+        "serialNumber": f"urn:uuid:{uuid.uuid4()}", "version": 1,
+        "metadata": {
+            "timestamp": snapshot.get("generated_at") or iso_utc_now(),
+            "tools": {"components": [{
+                "type": "application", "name": GENERATOR_NAME,
+                "version": GENERATOR_VERSION,
+                "description": "TLS Termination CBOM Generator (CycloneDX output)",
+            }]},
+            "component": prune_none(root_comp),
         },
-    }
-
-    # None 값 필터링
-    cbom["crypto_assets"] = {
-        k: v for k, v in cbom["crypto_assets"].items() if v is not None
-    }
-
-    return cbom
+        "components": list(comps.values()),
+        "dependencies": deps,
+        "properties": prune_none(bom_props),
+    })
 
 
-# ── CLI ──────────────────────────────────────────────────────────────────────
+# ═══════════════════════════════════════════════════════════════════════════════
+# 메인
+# ═══════════════════════════════════════════════════════════════════════════════
+
+def generate_cbom(
+    host=DEFAULT_HOST, port=DEFAULT_PORT, stage="auto", config_path="",
+    tester_container=DEFAULT_TESTER, server_container=DEFAULT_SERVER,
+    server_cert_path=DEFAULT_CERT_PATH, verify_script=DEFAULT_VERIFY_SCRIPT,
+    spec_version=DEFAULT_SPEC_VERSION, strict=False, redact=True,
+):
+    snapshot = build_analysis_snapshot(
+        host=host, port=port, stage=stage, config_path=config_path,
+        tester_container=tester_container, server_container=server_container,
+        server_cert_path=server_cert_path, verify_script=verify_script, strict=strict)
+    return convert_snapshot_to_cyclonedx(snapshot, spec_version=spec_version, redact=redact)
+
+
 def main():
     parser = argparse.ArgumentParser(
-        description="TLS Termination CBOM Generator",
+        description="TLS Termination CBOM Generator (CycloneDX 1.6 JSON)",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 사용 예시:
-  # Stage 2 검증 후 CBOM 생성
   python policy/cbom_gen.py --stage 2 --out artifacts/cbom_stage2.json
-
-  # CI 파이프라인에서 (STAGE 환경변수 자동 감지)
   python policy/cbom_gen.py --out artifacts/cbom.json
+  python policy/cbom_gen.py --stage 3 --strict-validation --no-redact
 
-  # 특정 nginx 설정 파일 지정
-  python policy/cbom_gen.py --stage 3 --config nginx/nginx-pq.conf
-        """,
-    )
-    parser.add_argument("--host", default=DEFAULT_HOST,
-                        help=f"검증 대상 호스트 (기본: {DEFAULT_HOST})")
-    parser.add_argument("--port", type=int, default=DEFAULT_PORT,
-                        help=f"검증 대상 포트 (기본: {DEFAULT_PORT})")
-    parser.add_argument("--stage", default="auto",
-                        help="auto | 1 | ecc | 2 | hybrid | 3 | pq (auto시 $STAGE 환경변수 자동 감지)")
-    parser.add_argument("--config", default="",
-                        help="nginx 설정 파일 경로 (미지정 시 stage에서 자동 선택)")
-    parser.add_argument("--tester-container", default=DEFAULT_TESTER,
-                        help=f"tester 컨테이너명 (기본: {DEFAULT_TESTER})")
-    parser.add_argument("--server-container", default=DEFAULT_SERVER,
-                        help=f"server 컨테이너명 (기본: {DEFAULT_SERVER})")
-    parser.add_argument("--server-cert-path", default=DEFAULT_CERT_PATH,
-                        help=f"서버 인증서 경로 (기본: {DEFAULT_CERT_PATH})")
-    parser.add_argument("--verify-script", default=DEFAULT_VERIFY_SCRIPT,
-                        help=f"검증 스크립트 (기본: {DEFAULT_VERIFY_SCRIPT})")
-    parser.add_argument("--out", default="",
-                        help="결과 저장 경로 (미지정 시 stdout만 출력)")
-    parser.add_argument(
-        "--strict-validation",
-        action=argparse.BooleanOptionalAction,
-        default=DEFAULT_STRICT_VALIDATION,
-        help="verify_tls.sh 판정과 cbom_gen 판정이 불일치하면 exit 3으로 종료",
-    )
+Exit codes:  0=정상  2=동적분석실패  3=교차검증불일치(strict)
+        """)
+    parser.add_argument("--host", default=DEFAULT_HOST)
+    parser.add_argument("--port", type=int, default=DEFAULT_PORT)
+    parser.add_argument("--stage", default="auto")
+    parser.add_argument("--config", default="")
+    parser.add_argument("--tester-container", default=DEFAULT_TESTER)
+    parser.add_argument("--server-container", default=DEFAULT_SERVER)
+    parser.add_argument("--server-cert-path", default=DEFAULT_CERT_PATH)
+    parser.add_argument("--verify-script", default=DEFAULT_VERIFY_SCRIPT)
+    parser.add_argument("--spec-version", default=DEFAULT_SPEC_VERSION)
+    parser.add_argument("--out", default="")
+    parser.add_argument("--strict-validation", action=argparse.BooleanOptionalAction, default=DEFAULT_STRICT_VALIDATION)
+    parser.add_argument("--redact", action=argparse.BooleanOptionalAction, default=DEFAULT_REDACT,
+                        help="BOM에서 내부 경로/분석 상세 제거 (기본: 제거)")
     args = parser.parse_args()
 
     cbom = generate_cbom(
-        host=args.host,
-        port=args.port,
-        stage=args.stage,
-        config_path=args.config,
-        tester_container=args.tester_container,
-        server_container=args.server_container,
-        server_cert_path=args.server_cert_path,
-        verify_script=args.verify_script,
-    )
+        host=args.host, port=args.port, stage=args.stage, config_path=args.config,
+        tester_container=args.tester_container, server_container=args.server_container,
+        server_cert_path=args.server_cert_path, verify_script=args.verify_script,
+        spec_version=args.spec_version, strict=args.strict_validation, redact=args.redact)
 
     text = json.dumps(cbom, indent=2, ensure_ascii=False)
     print(text)
@@ -713,21 +1246,22 @@ def main():
         out_path = Path(args.out)
         out_path.parent.mkdir(parents=True, exist_ok=True)
         out_path.write_text(text + "\n", encoding="utf-8")
-        print(f"\nCBOM 저장 완료: {out_path}", file=sys.stderr)
+        print(f"\nCBOM (CycloneDX {args.spec_version}) 저장 완료: {out_path}", file=sys.stderr)
 
-    # 검증 실패 시 CI에서 감지할 수 있도록 exit code 반환
-    if cbom.get("pqc_status") == "DYNAMIC_ANALYSIS_FAILED":
+    pqc_status = extract_root_property(cbom, "securecapstone:pqc_status")
+    if pqc_status == "DYNAMIC_ANALYSIS_FAILED":
         sys.exit(2)
 
-    validation = cbom.get("validation", {})
-    if not validation.get("consistent", True):
+    val_raw = extract_root_property(cbom, "securecapstone:validation")
+    val = {}
+    if val_raw:
+        try: val = json.loads(val_raw)
+        except json.JSONDecodeError: pass
+    if not val.get("consistent", True):
         if args.strict_validation:
             sys.exit(3)
-        warnings = validation.get("warnings", [])
-        if warnings:
-            print("\n[WARN] validation mismatch (strict mode off)", file=sys.stderr)
-            for msg in warnings:
-                print(f"- {msg}", file=sys.stderr)
+        for msg in val.get("warnings", []):
+            print(f"[WARN] {msg}", file=sys.stderr)
 
 
 if __name__ == "__main__":

--- a/policy/cbom_gen.py
+++ b/policy/cbom_gen.py
@@ -26,7 +26,6 @@ CycloneDX CLI로 검증:
 Exit codes:
   0 - 정상
   2 - 동적 분석 실패 (검증 스크립트 오류 포함)
-  3 - 교차 검증 불일치 (--strict-validation 시)
 """
 
 import argparse
@@ -44,7 +43,7 @@ from pathlib import Path
 
 # ── 상수 ──────────────────────────────────────────────────────────────────────
 GENERATOR_NAME = "cbom_gen.py"
-GENERATOR_VERSION = "2.2.1"
+GENERATOR_VERSION = "2.2.2"
 
 CYCLONEDX_SCHEMA_MAP = {
     "1.6": "https://cyclonedx.org/schema/bom-1.6.schema.json",
@@ -71,9 +70,6 @@ DEFAULT_TESTER = os.getenv("TESTER_CONTAINER", "tls-tester")
 DEFAULT_SERVER = os.getenv("SERVER_CONTAINER", "pqc-proxy")
 DEFAULT_CERT_PATH = os.getenv("SERVER_CERT_PATH", "/etc/nginx/certs/server.crt")
 DEFAULT_VERIFY_SCRIPT = os.getenv("VERIFY_SCRIPT", "tls_check.sh")
-DEFAULT_STRICT_VALIDATION = os.getenv("STRICT_VALIDATION", "false").strip().lower() in {
-    "1", "true", "yes", "on",
-}
 DEFAULT_SPEC_VERSION = os.getenv("CYCLONEDX_SPEC_VERSION", "1.6")
 DEFAULT_REDACT = os.getenv("CBOM_REDACT", "true").strip().lower() not in {
     "0", "false", "no", "off",
@@ -829,14 +825,11 @@ def parse_cert_info(cert_text: str) -> dict:
     return result
 
 
-def cross_validate(our_status, script_judgement, requested_stage, *, strict=False):
-    """교차 검증. strict=True이면 판정 파싱 실패 시에도 consistent=False."""
+def cross_validate(our_status, script_judgement, requested_stage):
+    """교차 검증 결과를 warnings/consistent 형태로 반환."""
     validation = {"consistent": True, "warnings": []}
     if not script_judgement:
         validation["warnings"].append("검증 스크립트 판정 결과를 파싱하지 못했습니다.")
-        if strict:
-            validation["consistent"] = False
-            validation["warnings"].append("엄격 모드: 판정 결과를 확인할 수 없으므로 검증 실패로 처리합니다.")
         return validation
 
     jl = script_judgement.lower()
@@ -933,7 +926,6 @@ def build_analysis_snapshot(
     host=DEFAULT_HOST, port=DEFAULT_PORT, stage="auto", config_path="",
     tester_container=DEFAULT_TESTER, server_container=DEFAULT_SERVER,
     server_cert_path=DEFAULT_CERT_PATH, verify_script=DEFAULT_VERIFY_SCRIPT,
-    strict=False,
 ):
     normalized_stage = normalize_stage(stage)
     resolved_config = resolve_config_path(normalized_stage, config_path)
@@ -981,7 +973,6 @@ def build_analysis_snapshot(
         our_status=pqc_status if pqc_status != "DYNAMIC_ANALYSIS_FAILED" else (partial or pqc_status),
         script_judgement=dynamic_f.get("verify_tls_judgement", ""),
         requested_stage=normalized_stage,
-        strict=strict,
     )
 
     snapshot = {
@@ -1197,12 +1188,12 @@ def generate_cbom(
     host=DEFAULT_HOST, port=DEFAULT_PORT, stage="auto", config_path="",
     tester_container=DEFAULT_TESTER, server_container=DEFAULT_SERVER,
     server_cert_path=DEFAULT_CERT_PATH, verify_script=DEFAULT_VERIFY_SCRIPT,
-    spec_version=DEFAULT_SPEC_VERSION, strict=False, redact=True,
+    spec_version=DEFAULT_SPEC_VERSION, redact=True,
 ):
     snapshot = build_analysis_snapshot(
         host=host, port=port, stage=stage, config_path=config_path,
         tester_container=tester_container, server_container=server_container,
-        server_cert_path=server_cert_path, verify_script=verify_script, strict=strict)
+        server_cert_path=server_cert_path, verify_script=verify_script)
     return convert_snapshot_to_cyclonedx(snapshot, spec_version=spec_version, redact=redact)
 
 
@@ -1214,9 +1205,9 @@ def main():
 사용 예시:
   python policy/cbom_gen.py --stage 2 --out artifacts/cbom_stage2.json
   python policy/cbom_gen.py --out artifacts/cbom.json
-  python policy/cbom_gen.py --stage 3 --strict-validation --no-redact
+  python policy/cbom_gen.py --stage 3 --no-redact
 
-Exit codes:  0=정상  2=동적분석실패  3=교차검증불일치(strict)
+Exit codes:  0=정상  2=동적분석실패
         """)
     parser.add_argument("--host", default=DEFAULT_HOST)
     parser.add_argument("--port", type=int, default=DEFAULT_PORT)
@@ -1228,7 +1219,6 @@ Exit codes:  0=정상  2=동적분석실패  3=교차검증불일치(strict)
     parser.add_argument("--verify-script", default=DEFAULT_VERIFY_SCRIPT)
     parser.add_argument("--spec-version", default=DEFAULT_SPEC_VERSION)
     parser.add_argument("--out", default="")
-    parser.add_argument("--strict-validation", action=argparse.BooleanOptionalAction, default=DEFAULT_STRICT_VALIDATION)
     parser.add_argument("--redact", action=argparse.BooleanOptionalAction, default=DEFAULT_REDACT,
                         help="BOM에서 내부 경로/분석 상세 제거 (기본: 제거)")
     args = parser.parse_args()
@@ -1237,7 +1227,7 @@ Exit codes:  0=정상  2=동적분석실패  3=교차검증불일치(strict)
         host=args.host, port=args.port, stage=args.stage, config_path=args.config,
         tester_container=args.tester_container, server_container=args.server_container,
         server_cert_path=args.server_cert_path, verify_script=args.verify_script,
-        spec_version=args.spec_version, strict=args.strict_validation, redact=args.redact)
+        spec_version=args.spec_version, redact=args.redact)
 
     text = json.dumps(cbom, indent=2, ensure_ascii=False)
     print(text)
@@ -1258,8 +1248,6 @@ Exit codes:  0=정상  2=동적분석실패  3=교차검증불일치(strict)
         try: val = json.loads(val_raw)
         except json.JSONDecodeError: pass
     if not val.get("consistent", True):
-        if args.strict_validation:
-            sys.exit(3)
         for msg in val.get("warnings", []):
             print(f"[WARN] {msg}", file=sys.stderr)
 


### PR DESCRIPTION
## 작업내용

- 기존 SecureCapstone CBOM 생성 로직을 **CycloneDX 1.6 JSON 구조**로 전환함  
  - `policy/cbom_gen.py` 출력 형식을 기존 커스텀 top-level JSON에서 `bomFormat`, `specVersion`, `metadata`, `components`, `dependencies`, `properties` 기반 구조로 변경
  - TLS termination 관점에서 **프로토콜 / 인증서 / 공개키 / 개인키 / 알고리즘**을 개별 cryptographic asset으로 모델링하도록 정리
  - 하이브리드/PQC 키 교환 표현 보강 및 cipher suite 내부 알고리즘 매핑 추가

- CBOM 생성 과정에서 기존 구현의 취약 지점도 함께 보완함  
  - 정규식 처리 오류 및 SHA/ML-KEM 분류 로직 보정
  - redact 시 내부 경로가 그대로 노출될 수 있는 부분 보완
  - nginx 설정 파싱 시 주석/중복 directive/엣지 케이스 처리 개선
  - protocol/cipher suite 관련 메타데이터가 CycloneDX 구조 안에서 더 일관되게 표현되도록 정리

- `policy/cbom_diff.py`를 CycloneDX 구조에 맞게 전면 수정함  
  - 기존 `migration_summary`, `classical_crypto_findings` 등 top-level 필드 직접 참조 제거
  - CycloneDX `properties` 배열 내 `securecapstone:*` 네임스페이스를 읽고 쓰는 방식으로 변경
  - `get_property()` / `set_property()` 헬퍼를 추가해 JSON value parsing 및 property overwrite 흐름 정리
  - diff 결과인 `migration_progress`도 `securecapstone:migration_progress` property로 기록하도록 변경

- GitHub Actions 파이프라인도 신규 구조에 맞춰 연동 수정함  
  - `.github/workflows/devsecops-pipeline.yml`에서 CBOM 후처리 시 top-level 직대입 대신 `securecapstone:*` property 삽입 방식으로 변경
  - Job Summary `jq` 조회 로직을 CycloneDX `properties[]` 기반 조회로 수정
  - PR 코멘트 스크립트도 기존 direct field access 대신 helper 기반 property 탐색으로 변경

- 결과적으로 이번 변경으로 **CBOM 생성 → diff → CI Summary → PR Comment**까지 전 구간이 동일한 CycloneDX 구조를 기준으로 동작하도록 정리함


## 주의 사항 및 참고 자료 (Optional)

- 이번 변경은 단순 출력 포맷 변경이 아니라, 기존 CBOM 소비 로직까지 함께 바뀌는 작업이므로  
  **기존 top-level 필드(`migration_summary`, `migration_progress`, `classical_crypto_findings`)를 직접 참조하던 스크립트가 남아 있으면 추가 확인 필요**
- 현재 파이프라인 기준 기본 사용 스펙은 **CycloneDX 1.6**
- 커스텀 후처리 데이터는 CycloneDX 표준 필드가 아니라 `properties` 배열 내 `securecapstone:*` 네임스페이스로 저장됨
- 관련 주요 수정 파일
  - `policy/cbom_gen.py`
  - `policy/cbom_diff.py`
  - `.github/workflows/devsecops-pipeline.yml`
