### PR TITLE
feat(scanner): add TLS check result to pipeline Job Summary

### DIFF
--- a/.github/workflows/devsecops-pipeline.yml
+++ b/.github/workflows/devsecops-pipeline.yml
@@ -218,7 +218,7 @@ jobs:
           tls_check_status=$?
           set -e
           mkdir -p scanner/results
-          docker cp tls-tester:/usr/local/bin/results/tls-check-summary.json scanner/results/tls-check-summary.json
+          docker cp tls-tester:/usr/local/bin/results/tls-check-summary.json scanner/results/tls-check-summary.json || true
           exit $tls_check_status
 
       - name: 10. CBOM 명세서 생성 및 리포팅
@@ -319,7 +319,13 @@ jobs:
           PROGRESS=$(jq -r '.migration_progress.status // "N/A"' "artifacts/cbom_stage${STAGE}.json" 2>/dev/null || echo "N/A")
           MANUAL=$(jq -r '.migration_summary.manual_action_required // "N/A"' "artifacts/cbom_stage${STAGE}.json" 2>/dev/null || echo "N/A")
 
-          icon() { [ "$1" = "pass" ] && echo "✅" || echo "❌"; }
+          icon() {
+            case "$1" in
+              pass) echo "✅" ;;
+              fail) echo "❌" ;;
+              *)    echo "⚠️" ;;
+            esac
+          }
 
           cat >> $GITHUB_STEP_SUMMARY << SUMMARY
           ## DevSecOps PQC Pipeline — Stage ${STAGE}

--- a/.github/workflows/devsecops-pipeline.yml
+++ b/.github/workflows/devsecops-pipeline.yml
@@ -213,9 +213,13 @@ jobs:
       - name: 9. 배포 후 동적 검증 (TLS 협상 확인)
         run: |
           echo "진행 중: 서버로 TLS 연결 시도 및 PQC 그룹 확인..."
+          set +e
           docker exec tls-tester tls_check.sh proxy-server 443 ${{ env.STAGE }}
+          tls_check_status=$?
+          set -e
           mkdir -p scanner/results
           docker cp tls-tester:/usr/local/bin/results/tls-check-summary.json scanner/results/tls-check-summary.json
+          exit $tls_check_status
 
       - name: 10. CBOM 명세서 생성 및 리포팅
         run: |

--- a/.github/workflows/devsecops-pipeline.yml
+++ b/.github/workflows/devsecops-pipeline.yml
@@ -214,6 +214,8 @@ jobs:
         run: |
           echo "진행 중: 서버로 TLS 연결 시도 및 PQC 그룹 확인..."
           docker exec tls-tester tls_check.sh proxy-server 443 ${{ env.STAGE }}
+          mkdir -p scanner/results
+          docker cp tls-tester:/usr/local/bin/results/tls-check-summary.json scanner/results/tls-check-summary.json
 
       - name: 10. CBOM 명세서 생성 및 리포팅
         run: |

--- a/.github/workflows/devsecops-pipeline.yml
+++ b/.github/workflows/devsecops-pipeline.yml
@@ -308,6 +308,7 @@ jobs:
           TRIVY=$(jq -r '.tools.trivy // "unknown"' scanner/results/scan-summary.json 2>/dev/null || echo "unknown")
           GITLEAKS=$(jq -r '.tools.gitleaks // "unknown"' scanner/results/scan-summary.json 2>/dev/null || echo "unknown")
           SEMGREP=$(jq -r '.tools.semgrep // "unknown"' scanner/results/scan-summary.json 2>/dev/null || echo "unknown")
+          TLS_CHECK=$(jq -r '.result // "unknown"' scanner/results/tls-check-summary.json 2>/dev/null || echo "unknown")
           FINDINGS=$(jq '.results | length' artifacts/crypto-findings.json 2>/dev/null || echo 0)
           PROGRESS=$(jq -r '.migration_progress.status // "N/A"' "artifacts/cbom_stage${STAGE}.json" 2>/dev/null || echo "N/A")
           MANUAL=$(jq -r '.migration_summary.manual_action_required // "N/A"' "artifacts/cbom_stage${STAGE}.json" 2>/dev/null || echo "N/A")
@@ -323,6 +324,7 @@ jobs:
           | Trivy (CVE) | $(icon $TRIVY) ${TRIVY} |
           | Gitleaks (Secrets) | $(icon $GITLEAKS) ${GITLEAKS} |
           | Semgrep (SAST) | $(icon $SEMGREP) ${SEMGREP} |
+          | TLS 동적 검증 | $(icon $TLS_CHECK) ${TLS_CHECK} |
 
           ### 레거시 암호 탐지
           - 탐지 건수: **${FINDINGS}건**


### PR DESCRIPTION
## 변경 내용

### 문제
Step ⑨(배포 후 동적 검증)에서 tls_check.sh 실행 결과가
Job Summary에 반영되지 않고 있었음.
tls-check-summary.json이 컨테이너 내부에만 생성되고
호스트(runner)에서 읽을 수 없는 구조였기 때문.

### 수정
1. Step ⑨ 실행 후 docker cp로 결과 파일을 호스트로 복사
   - tls-tester:/usr/local/bin/results/tls-check-summary.json
   → scanner/results/tls-check-summary.json

2. Job Summary 스캔 결과 표에 TLS 동적 검증 행 추가
   - tls-check-summary.json의 result 필드를 읽어 pass/fail 표시

## 검증
- Stage 2 기준 파이프라인 전체 실행 완료
- Job Summary에 TLS 동적 검증 ✅ pass 표시 확인