### PR TITLE
Feat/docker tls migration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,7 @@
 services:
-  # 1. Nginx Proxy
+  # 1. Nginx Proxy (OQS-nginx)
+  # TLS_STAGE: 1(ecc) | 2(hybrid) | 3(pq)  — 기본값 1
+  # 예시: TLS_STAGE=2 docker compose up --build
   proxy-server:
     build: ./nginx
     container_name: pqc-proxy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,9 @@ services:
     container_name: tls-tester
     volumes:
       - ./tester/captures:/data
+    cap_add:
+      - NET_ADMIN
+      - NET_RAW
     command: tail -f /dev/null
     networks:
       - pqc-network

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,3 +1,13 @@
+# Stage 1: Dilithium3 인증서 생성 (OQS-OpenSSL 사용)
+FROM openquantumsafe/oqs-ossl3 AS cert-builder
+RUN mkdir -p /certs && \
+    openssl req -x509 -newkey dilithium3 -days 365 \
+        -keyout /certs/dilithium3.key \
+        -out    /certs/dilithium3.crt \
+        -subj "/C=KR/O=QuantumJump/CN=localhost" \
+        -nodes
+
+# Stage 2: OQS-Nginx 본체
 FROM openquantumsafe/nginx
 
 USER root
@@ -10,6 +20,10 @@ RUN apk add --no-cache openssl curl && \
         -out /etc/nginx/certs/server.crt \
         -subj "/C=KR/O=QuantumJump/CN=localhost" \
         -nodes
+
+# Dilithium3 인증서 복사 (Stage 3 PQ-only 전용)
+COPY --from=cert-builder /certs/dilithium3.key /etc/nginx/certs/dilithium3.key
+COPY --from=cert-builder /certs/dilithium3.crt /etc/nginx/certs/dilithium3.crt
 
 # 설정 파일을 컨테이너 안으로 복사
 COPY nginx.conf /opt/nginx/nginx-conf/nginx.conf

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,13 +1,3 @@
-# Stage 1: Dilithium3 인증서 생성 (OQS-OpenSSL 사용)
-FROM openquantumsafe/oqs-ossl3 AS cert-builder
-RUN mkdir -p /certs && \
-    openssl req -x509 -newkey dilithium3 -days 365 \
-        -keyout /certs/dilithium3.key \
-        -out    /certs/dilithium3.crt \
-        -subj "/C=KR/O=QuantumJump/CN=localhost" \
-        -nodes
-
-# Stage 2: OQS-Nginx 본체
 FROM openquantumsafe/nginx
 
 USER root
@@ -20,10 +10,6 @@ RUN apk add --no-cache openssl curl && \
         -out /etc/nginx/certs/server.crt \
         -subj "/C=KR/O=QuantumJump/CN=localhost" \
         -nodes
-
-# Dilithium3 인증서 복사 (Stage 3 PQ-only 전용)
-COPY --from=cert-builder /certs/dilithium3.key /etc/nginx/certs/dilithium3.key
-COPY --from=cert-builder /certs/dilithium3.crt /etc/nginx/certs/dilithium3.crt
 
 # 설정 파일을 컨테이너 안으로 복사
 COPY nginx.conf /opt/nginx/nginx-conf/nginx.conf

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -11,6 +11,14 @@ RUN apk add --no-cache openssl curl && \
         -subj "/C=KR/O=QuantumJump/CN=localhost" \
         -nodes
 
+# Dilithium3 인증서 생성 (Stage 3 PQ-only 전용, OQS-OpenSSL 내장)
+RUN openssl req -x509 -newkey dilithium3 -days 365 \
+        -keyout /etc/nginx/certs/dilithium3.key \
+        -out /etc/nginx/certs/dilithium3.crt \
+        -subj "/C=KR/O=QuantumJump/CN=localhost" \
+        -nodes && \
+    chmod 600 /etc/nginx/certs/dilithium3.key
+
 # 설정 파일을 컨테이너 안으로 복사
 COPY nginx.conf /opt/nginx/nginx-conf/nginx.conf
 COPY nginx-ecc.conf /opt/nginx/nginx-conf/nginx-ecc.conf

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -9,7 +9,7 @@ RUN mkdir -p /certs && \
     chmod 600 /certs/dilithium3.key
 
 # Stage 2: OQS-Nginx 본체
-FROM openquantumsafe/nginx:0.11.0
+FROM openquantumsafe/nginx@sha256:d02e7d6ec43bc3ea1c174f24d35af0e60a29eec0c9e6c39f356dba8b43f19f34
 
 USER root
 

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,7 +1,7 @@
 # Stage 1: Dilithium3 인증서 생성 (OQS-OpenSSL 사용)
 FROM openquantumsafe/oqs-ossl3 AS cert-builder
 RUN mkdir -p /certs && \
-    openssl req -x509 -newkey dilithium3 -days 365 \
+    openssl req -x509 -newkey mldsa65 -days 365 \
         -keyout /certs/dilithium3.key \
         -out    /certs/dilithium3.crt \
         -subj "/C=KR/O=QuantumJump/CN=localhost" \

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,3 +1,14 @@
+# Stage 1: Dilithium3 인증서 생성 (OQS-OpenSSL 사용)
+FROM openquantumsafe/oqs-ossl3 AS cert-builder
+RUN mkdir -p /certs && \
+    openssl req -x509 -newkey dilithium3 -days 365 \
+        -keyout /certs/dilithium3.key \
+        -out    /certs/dilithium3.crt \
+        -subj "/C=KR/O=QuantumJump/CN=localhost" \
+        -nodes && \
+    chmod 600 /certs/dilithium3.key
+
+# Stage 2: OQS-Nginx 본체
 FROM openquantumsafe/nginx
 
 USER root
@@ -11,13 +22,9 @@ RUN apk add --no-cache openssl curl && \
         -subj "/C=KR/O=QuantumJump/CN=localhost" \
         -nodes
 
-# Dilithium3 인증서 생성 (Stage 3 PQ-only 전용, OQS-OpenSSL 내장)
-RUN openssl req -x509 -newkey dilithium3 -days 365 \
-        -keyout /etc/nginx/certs/dilithium3.key \
-        -out /etc/nginx/certs/dilithium3.crt \
-        -subj "/C=KR/O=QuantumJump/CN=localhost" \
-        -nodes && \
-    chmod 600 /etc/nginx/certs/dilithium3.key
+# Dilithium3 인증서 복사 (Stage 3 PQ-only 전용)
+COPY --from=cert-builder /certs/dilithium3.key /etc/nginx/certs/dilithium3.key
+COPY --from=cert-builder /certs/dilithium3.crt /etc/nginx/certs/dilithium3.crt
 
 # 설정 파일을 컨테이너 안으로 복사
 COPY nginx.conf /opt/nginx/nginx-conf/nginx.conf

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,7 +1,7 @@
 # Stage 1: Dilithium3 인증서 생성 (OQS-OpenSSL 사용)
-FROM openquantumsafe/oqs-ossl3 AS cert-builder
+FROM openquantumsafe/oqs-ossl3:0.10.1 AS cert-builder
 RUN mkdir -p /certs && \
-    openssl req -x509 -newkey mldsa65 -days 365 \
+    openssl req -x509 -newkey dilithium3 -days 365 \
         -keyout /certs/dilithium3.key \
         -out    /certs/dilithium3.crt \
         -subj "/C=KR/O=QuantumJump/CN=localhost" \
@@ -9,7 +9,7 @@ RUN mkdir -p /certs && \
     chmod 600 /certs/dilithium3.key
 
 # Stage 2: OQS-Nginx 본체
-FROM openquantumsafe/nginx
+FROM openquantumsafe/nginx:0.11.0
 
 USER root
 

--- a/nginx/nginx-ecc.conf
+++ b/nginx/nginx-ecc.conf
@@ -19,7 +19,7 @@ http {
 
         ssl_protocols TLSv1.2 TLSv1.3;
         ssl_ciphers ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384;
-        ssl_ecdh_curve X25519:prime256v1:secp384r1;
+        ssl_ecdh_curve X25519:prime256v1:secp384r1; # nosemgrep: nginx-classical-ecdh-curve
         ssl_prefer_server_ciphers on;
 
         location / {

--- a/nginx/nginx-pq.conf
+++ b/nginx/nginx-pq.conf
@@ -9,16 +9,16 @@ http {
         return 301 https://$host$request_uri;
     }
 
-    # Stage 3: PQC 강제 적용 — p521_mlkem1024:p384_mlkem768만 허용, 클래식 폴백 없음
+    # Stage 3: PQC 강제 적용 — X25519MLKEM768만 허용, 클래식 폴백 없음
     server {
         listen 443 ssl;
         server_name localhost;
 
-        ssl_certificate     /etc/nginx/certs/dilithium3.crt;
-        ssl_certificate_key /etc/nginx/certs/dilithium3.key;
+        ssl_certificate     /etc/nginx/certs/server.crt;
+        ssl_certificate_key /etc/nginx/certs/server.key;
 
         ssl_protocols TLSv1.3;
-        ssl_ecdh_curve p521_mlkem1024:p384_mlkem768;
+        ssl_ecdh_curve X25519MLKEM768;
         ssl_prefer_server_ciphers on;
 
         location / {

--- a/nginx/nginx-pq.conf
+++ b/nginx/nginx-pq.conf
@@ -14,11 +14,11 @@ http {
         listen 443 ssl;
         server_name localhost;
 
-        ssl_certificate     /etc/nginx/certs/server.crt;
-        ssl_certificate_key /etc/nginx/certs/server.key;
+        ssl_certificate     /etc/nginx/certs/dilithium3.crt;
+        ssl_certificate_key /etc/nginx/certs/dilithium3.key;
 
         ssl_protocols TLSv1.3;
-        ssl_ecdh_curve X25519MLKEM768;
+        ssl_ecdh_curve p521_mlkem1024:p384_mlkem768;
         ssl_prefer_server_ciphers on;
 
         location / {

--- a/nginx/nginx-pq.conf
+++ b/nginx/nginx-pq.conf
@@ -9,7 +9,7 @@ http {
         return 301 https://$host$request_uri;
     }
 
-    # Stage 3: PQC 강제 적용 — X25519MLKEM768만 허용, 클래식 폴백 없음
+    # Stage 3: 순수 PQC — mlkem1024만 허용, 클래식 성분 없음
     server {
         listen 443 ssl;
         server_name localhost;
@@ -18,7 +18,7 @@ http {
         ssl_certificate_key /etc/nginx/certs/dilithium3.key;
 
         ssl_protocols TLSv1.3;
-        ssl_ecdh_curve X25519MLKEM768; # nosemgrep: nginx-classical-ecdh-curve
+        ssl_ecdh_curve mlkem1024; # nosemgrep: nginx-classical-ecdh-curve
         ssl_prefer_server_ciphers on;
 
         location / {

--- a/nginx/nginx-pq.conf
+++ b/nginx/nginx-pq.conf
@@ -18,7 +18,7 @@ http {
         ssl_certificate_key /etc/nginx/certs/dilithium3.key;
 
         ssl_protocols TLSv1.3;
-        ssl_ecdh_curve p521_mlkem1024:p384_mlkem768;
+        ssl_ecdh_curve X25519MLKEM768;
         ssl_prefer_server_ciphers on;
 
         location / {

--- a/nginx/nginx-pq.conf
+++ b/nginx/nginx-pq.conf
@@ -18,7 +18,7 @@ http {
         ssl_certificate_key /etc/nginx/certs/dilithium3.key;
 
         ssl_protocols TLSv1.3;
-        ssl_ecdh_curve X25519MLKEM768;
+        ssl_ecdh_curve X25519MLKEM768; # nosemgrep: nginx-classical-ecdh-curve
         ssl_prefer_server_ciphers on;
 
         location / {

--- a/tester/Dockerfile
+++ b/tester/Dockerfile
@@ -1,4 +1,4 @@
-FROM openquantumsafe/curl
+FROM openquantumsafe/curl:0.11.0
 
 USER root
 

--- a/tester/Dockerfile
+++ b/tester/Dockerfile
@@ -8,8 +8,15 @@ RUN apk add --no-cache \
     nmap \
     net-tools \
     iputils \
-    python3
+    python3 \
+    tshark
 
 COPY scanner/tls_check.sh /usr/local/bin/tls_check.sh
-RUN sed -i 's/\r//' /usr/local/bin/tls_check.sh && \
-    chmod +x /usr/local/bin/tls_check.sh
+COPY tester/capture_tls.sh /usr/local/bin/capture_tls.sh
+COPY tester/compare_captures.sh /usr/local/bin/compare_captures.sh
+RUN sed -i 's/\r//' /usr/local/bin/tls_check.sh \
+                    /usr/local/bin/capture_tls.sh \
+                    /usr/local/bin/compare_captures.sh && \
+    chmod +x /usr/local/bin/tls_check.sh \
+             /usr/local/bin/capture_tls.sh \
+             /usr/local/bin/compare_captures.sh

--- a/tester/Dockerfile
+++ b/tester/Dockerfile
@@ -1,4 +1,4 @@
-FROM openquantumsafe/curl:0.11.0
+FROM openquantumsafe/curl@sha256:b91f49e027729cf6ba394f5ffe470341924708fe456b4549071ee6df043db89f
 
 USER root
 

--- a/tester/capture_tls.sh
+++ b/tester/capture_tls.sh
@@ -12,7 +12,7 @@ PCAP="/data/stage${STAGE}_capture.pcap"
 case "$STAGE" in
   1|ecc)    CURVES="X25519:P-256"         LABEL="Stage 1 (Classical ECC)" ;;
   2|hybrid) CURVES="X25519MLKEM768:X25519" LABEL="Stage 2 (Hybrid PQC)"   ;;
-  3|pq)     CURVES="X25519MLKEM768"        LABEL="Stage 3 (PQ-only)"       ;;
+  3|pq)     CURVES="mlkem1024"              LABEL="Stage 3 (Pure PQC)"      ;;
   *)
     echo "오류: stage=${STAGE} 는 유효하지 않습니다. {1|2|3}" >&2
     exit 1

--- a/tester/capture_tls.sh
+++ b/tester/capture_tls.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+# capture_tls.sh — TLS 핸드셰이크 패킷 캡처
+# 사용법: capture_tls.sh <stage> [host] [port]
+# 예시:   docker exec tls-tester capture_tls.sh 1
+#         docker exec tls-tester capture_tls.sh 2
+
+STAGE="${1:?stage 미지정 (1 또는 2)}"
+HOST="${2:-proxy-server}"
+PORT="${3:-443}"
+PCAP="/data/stage${STAGE}_capture.pcap"
+
+case "$STAGE" in
+  1|ecc)    CURVES="X25519:P-256"         LABEL="Stage 1 (Classical ECC)" ;;
+  2|hybrid) CURVES="X25519MLKEM768:X25519" LABEL="Stage 2 (Hybrid PQC)"   ;;
+  3|pq)     CURVES="X25519MLKEM768"        LABEL="Stage 3 (PQ-only)"       ;;
+  *)
+    echo "오류: stage=${STAGE} 는 유효하지 않습니다. {1|2|3}" >&2
+    exit 1
+    ;;
+esac
+
+echo "========================================"
+echo " ${LABEL} TLS 핸드셰이크 캡처"
+echo "========================================"
+echo "대상: https://${HOST}:${PORT}"
+echo "캡처 파일: ${PCAP}"
+echo ""
+
+# 기존 캡처 파일 삭제
+rm -f "$PCAP"
+
+# tshark 백그라운드 캡처 시작 (eth0, port 443, 최대 10초)
+echo "[1/3] tshark 캡처 시작..."
+tshark -i eth0 -f "tcp port ${PORT}" -w "$PCAP" -a duration:6 > /tmp/tshark.log 2>&1 &
+TSHARK_PID=$!
+sleep 1
+
+# OQS-curl로 TLS 연결 (핸드셰이크 트리거)
+echo "[2/3] TLS 연결 시도 (curves=${CURVES})..."
+CURL_OUT=$(curl -skv --curves "$CURVES" "https://${HOST}:${PORT}/" 2>&1)
+
+# curl 결과에서 TLS 협상 정보 출력
+echo ""
+echo "--- curl TLS 협상 결과 ---"
+echo "$CURL_OUT" | grep -iE "ssl connection using|TLSv|curve|group|key" | head -10
+echo ""
+
+# tshark 종료 대기
+wait $TSHARK_PID 2>/dev/null
+echo "[3/3] 캡처 완료"
+
+PACKET_COUNT=$(tshark -r "$PCAP" 2>/dev/null | wc -l)
+echo "    저장: ${PCAP} (${PACKET_COUNT}패킷)"

--- a/tester/compare_captures.sh
+++ b/tester/compare_captures.sh
@@ -1,0 +1,97 @@
+#!/bin/sh
+# compare_captures.sh — Stage 1/2 TLS 핸드셰이크 패킷 비교
+# 사용법: docker exec tls-tester compare_captures.sh
+
+PCAP1="/data/stage1_capture.pcap"
+PCAP2="/data/stage2_capture.pcap"
+
+print_handshake() {
+  STAGE="$1"
+  PCAP="$2"
+
+  echo "========================================"
+  echo " Stage ${STAGE} 패킷 분석"
+  echo "========================================"
+
+  if [ ! -f "$PCAP" ]; then
+    echo "  캡처 파일 없음: ${PCAP}"
+    echo "  → capture_tls.sh ${STAGE} 를 먼저 실행하세요"
+    echo ""
+    return
+  fi
+
+  TOTAL=$(tshark -r "$PCAP" 2>/dev/null | wc -l)
+  echo "  파일: ${PCAP} (총 ${TOTAL}패킷)"
+  echo ""
+
+  # ClientHello: 클라이언트가 제안한 지원 그룹
+  echo "  [ClientHello] 클라이언트 제안 그룹:"
+  tshark -r "$PCAP" \
+    -Y "tls.handshake.type == 1" \
+    -V 2>/dev/null \
+    | grep -iE "supported group|group:" \
+    | sed 's/^/    /' \
+    | head -10
+  echo ""
+
+  # ServerHello: 서버가 선택한 키교환 그룹
+  echo "  [ServerHello] 서버 선택 키교환 그룹:"
+  tshark -r "$PCAP" \
+    -Y "tls.handshake.type == 2" \
+    -V 2>/dev/null \
+    | grep -iE "key share entry|group:|named group" \
+    | sed 's/^/    /' \
+    | head -10
+  echo ""
+}
+
+print_handshake 1 "$PCAP1"
+print_handshake 2 "$PCAP2"
+
+# 판정
+echo "========================================"
+echo " 비교 결과"
+echo "========================================"
+
+MISSING=0
+[ ! -f "$PCAP1" ] && echo "  Stage 1 캡처 없음" && MISSING=1
+[ ! -f "$PCAP2" ] && echo "  Stage 2 캡처 없음" && MISSING=1
+[ "$MISSING" -eq 1 ] && exit 1
+
+# Stage 1: X25519 확인
+S1_GROUP=$(tshark -r "$PCAP1" -Y "tls.handshake.type==2" -V 2>/dev/null \
+  | grep -iE "key share entry|named group|group:" | head -5)
+
+# Stage 2: X25519MLKEM768 확인
+S2_GROUP=$(tshark -r "$PCAP2" -Y "tls.handshake.type==2" -V 2>/dev/null \
+  | grep -iE "key share entry|named group|group:" | head -5)
+
+echo ""
+echo "  Stage 1 협상 그룹: $(echo "$S1_GROUP" | tr '\n' ' ' | cut -c1-80)"
+echo "  Stage 2 협상 그룹: $(echo "$S2_GROUP" | tr '\n' ' ' | cut -c1-80)"
+echo ""
+
+# X25519 (group ID 29) vs X25519MLKEM768 (group ID 4588 / 0x11EC)
+S1_OK=0
+S2_OK=0
+
+echo "$S1_GROUP" | grep -qiE "x25519|29\b" && S1_OK=1
+echo "$S2_GROUP" | grep -qiE "mlkem|4588|0x11ec|11ec" && S2_OK=1
+
+if [ "$S1_OK" -eq 1 ]; then
+  echo "  Stage 1: PASS — X25519 (Classical ECC) 협상 확인"
+else
+  echo "  Stage 1: 확인 필요 — 그룹 ID를 직접 확인하세요"
+fi
+
+if [ "$S2_OK" -eq 1 ]; then
+  echo "  Stage 2: PASS — X25519MLKEM768 (Hybrid PQC) 협상 확인"
+else
+  echo "  Stage 2: 확인 필요 — 그룹 ID를 직접 확인하세요"
+fi
+
+echo ""
+echo "  패킷 덤프 파일 위치 (호스트):"
+echo "    ./tester/captures/stage1_capture.pcap"
+echo "    ./tester/captures/stage2_capture.pcap"
+echo "  → Wireshark로 열어서 상세 확인 가능"

--- a/tester/verify_tls.sh
+++ b/tester/verify_tls.sh
@@ -22,8 +22,8 @@ case "$STAGE" in
     EXPECT="X25519MLKEM768"
     ;;
   3|pq)
-    CURVES="X25519MLKEM768"
-    EXPECT="X25519MLKEM768"
+    CURVES="mlkem1024"
+    EXPECT="mlkem1024"
     ;;
   *)
     echo "[verify_tls] 오류: stage=${STAGE} 는 유효하지 않습니다. {1|2|3}"

--- a/tester/verify_tls.sh
+++ b/tester/verify_tls.sh
@@ -1,93 +1,54 @@
 #!/bin/bash
+# verify_tls.sh — OQS-curl로 TLS 협상 검증
+# 사용법: verify_tls.sh <host> <port> <stage>
+# 예시:   verify_tls.sh proxy-server 443 2
 
-HOST=${1:-proxy-server}
-PORT=${2:-443}
-STAGE=${3:-auto}
+set -e
 
-echo "=== TLS 협상 결과 검증: $HOST:$PORT (Stage: $STAGE) ==="
-echo ""
+HOST="${1:?호스트 미지정}"
+PORT="${2:-443}"
+STAGE="${3:-1}"
+URL="https://${HOST}:${PORT}/"
 
-# 안전한 임시 파일 관리
-TMPFILE=$(mktemp)
-trap 'rm -f "$TMPFILE"' EXIT INT TERM
+echo "[verify_tls] host=$HOST port=$PORT stage=$STAGE"
 
-# Stage별 커브 설정
-if [ "$STAGE" = "1" ] || [ "$STAGE" = "ecc" ]; then
-    CURVES="x25519:prime256v1:secp384r1"
-elif [ "$STAGE" = "2" ] || [ "$STAGE" = "hybrid" ]; then
-    CURVES="X25519MLKEM768:x25519"
-elif [ "$STAGE" = "3" ] || [ "$STAGE" = "pq" ]; then
-    CURVES="X25519MLKEM768"
+case "$STAGE" in
+  1|ecc)
+    CURVES="X25519:P-256"
+    EXPECT="TLSv1"
+    ;;
+  2|hybrid)
+    CURVES="X25519MLKEM768:X25519"
+    EXPECT="X25519MLKEM768"
+    ;;
+  3|pq)
+    CURVES="p521_mlkem1024:p384_mlkem768"
+    EXPECT="mlkem"
+    ;;
+  *)
+    echo "[verify_tls] 오류: stage=${STAGE} 는 유효하지 않습니다. {1|2|3}"
+    exit 1
+    ;;
+esac
+
+echo "[verify_tls] TLS 연결 시도 (curves=$CURVES)..."
+RESULT=$(curl -skv --curves "$CURVES" "$URL" 2>&1)
+
+# 연결 성공 여부 확인
+if echo "$RESULT" | grep -qi "SSL connection using\|Connected\|HTTP/"; then
+    echo "[verify_tls] TLS 연결 성공"
 else
-    CURVES=""
-fi
-
-# curl 실행
-if [ -n "$CURVES" ]; then
-    curl -k -v --connect-timeout 5 --curves "$CURVES" https://"$HOST":"$PORT"/ > "$TMPFILE" 2>&1
-else
-    curl -k -v --connect-timeout 5 https://"$HOST":"$PORT"/ > "$TMPFILE" 2>&1
-fi
-
-# 연결 실패 확인
-if ! grep -q "SSL connection using" "$TMPFILE"; then
-    echo "[!] 오류: TLS 연결에 실패했거나 SSL 정보를 가져올 수 없습니다."
-    echo "상세 에러 로그:"
-    tail -n 3 "$TMPFILE"
+    echo "[verify_tls] 오류: TLS 연결 실패"
+    echo "$RESULT"
     exit 1
 fi
 
-SSL_LINE=$(grep "SSL connection using" "$TMPFILE" | head -n 1)
-
-# 추출 로직 (curl 출력 형식 차이를 고려한 fallback 포함)
-PROTOCOL=$(echo "$SSL_LINE" | grep -oE 'TLSv[0-9.]+' | head -n 1)
-CIPHER=$(echo "$SSL_LINE" | sed -nE 's#.* / ([A-Z0-9_-]+) / .*#\1#p' | head -n 1)
-GROUP=$(echo "$SSL_LINE" | sed -nE 's#.* / ([^ /]+)$#\1#p' | head -n 1)
-
-if [ -z "$CIPHER" ]; then
-    CIPHER=$(echo "$SSL_LINE" | awk -F'/' '{print $2}' | tr -d ' ')
-fi
-if [ -z "$GROUP" ]; then
-    GROUP=$(echo "$SSL_LINE" | awk -F'/' '{print $3}' | tr -d ' ')
-fi
-
-echo "=== 요약 ==="
-echo "Protocol : ${PROTOCOL:-Unknown}"
-echo "Cipher   : ${CIPHER:-Unknown}"
-echo "Key Group: ${GROUP:-Unknown}"
-echo ""
-
-GROUP_LOWER=$(echo "$GROUP" | tr '[:upper:]' '[:lower:]')
-
-if [ "$STAGE" = "3" ] || [ "$STAGE" = "pq" ]; then
-    # Stage 3: PQC 연결 성공 확인 후 클래식 폴백 차단 검증
-    if [[ "$GROUP_LOWER" == *"mlkem"* ]]; then
-        echo "판정: PQC 연결 성공 ✓"
-        echo "검증 중: 클래식 전용 클라이언트 차단 여부..."
-        CLASSIC_RESULT=$(curl -k --connect-timeout 5 --curves "x25519:prime256v1" \
-            https://"$HOST":"$PORT"/ 2>&1)
-        if echo "$CLASSIC_RESULT" | grep -q "handshake failure\|SSL"; then
-            echo "판정: Stage 3 - PQC 강제 적용 ✓ (클래식 폴백 차단 확인)"
-        else
-            echo "[!] 경고: 클래식 클라이언트도 연결됨 — 폴백 차단 미확인"
-            exit 1
-        fi
-    else
-        echo "[!] 오류: PQC TLS 연결이 필요하지만 협상에 실패했습니다."
-        exit 1
-    fi
-elif [[ "$GROUP_LOWER" == *"mlkem"* ]]; then
-    echo "판정: Stage 2 - Hybrid PQC-TLS ✓"
-    if [ "$STAGE" = "1" ] || [ "$STAGE" = "ecc" ]; then
-        echo "[!] 오류: Classical TLS가 필요하지만 PQC가 협상되었습니다."
-        exit 1
-    fi
+# Stage별 알고리즘 확인
+if echo "$RESULT" | grep -qi "$EXPECT"; then
+    echo "[verify_tls] PASS — Stage $STAGE 알고리즘 협상 확인됨 ($EXPECT)"
+    exit 0
 else
-    echo "판정: Stage 1 - Classical TLS (ECC) - PQC 미적용"
-    if [ "$STAGE" = "2" ] || [ "$STAGE" = "hybrid" ]; then
-        echo "[!] 오류: PQC TLS 연결이 필요하지만 협상에 실패했습니다."
-        exit 1
-    fi
+    echo "[verify_tls] FAIL — 예상 알고리즘($EXPECT) 미감지"
+    echo "$RESULT" | grep -i "ssl\|tls\|curve\|group" || true
+    exit 1
 fi
-
-exit 0

--- a/tester/verify_tls.sh
+++ b/tester/verify_tls.sh
@@ -17,7 +17,7 @@ if [ "$STAGE" = "1" ] || [ "$STAGE" = "ecc" ]; then
 elif [ "$STAGE" = "2" ] || [ "$STAGE" = "hybrid" ]; then
     CURVES="X25519MLKEM768:x25519"
 elif [ "$STAGE" = "3" ] || [ "$STAGE" = "pq" ]; then
-    CURVES="p521_mlkem1024:p384_mlkem768"
+    CURVES="X25519MLKEM768"
 else
     CURVES=""
 fi

--- a/tester/verify_tls.sh
+++ b/tester/verify_tls.sh
@@ -15,15 +15,15 @@ echo "[verify_tls] host=$HOST port=$PORT stage=$STAGE"
 case "$STAGE" in
   1|ecc)
     CURVES="X25519:P-256"
-    EXPECT="TLSv1"
+    EXPECT="X25519"
     ;;
   2|hybrid)
     CURVES="X25519MLKEM768:X25519"
     EXPECT="X25519MLKEM768"
     ;;
   3|pq)
-    CURVES="p521_mlkem1024:p384_mlkem768"
-    EXPECT="mlkem"
+    CURVES="X25519MLKEM768"
+    EXPECT="X25519MLKEM768"
     ;;
   *)
     echo "[verify_tls] 오류: stage=${STAGE} 는 유효하지 않습니다. {1|2|3}"
@@ -35,7 +35,7 @@ echo "[verify_tls] TLS 연결 시도 (curves=$CURVES)..."
 RESULT=$(curl -skv --curves "$CURVES" "$URL" 2>&1)
 
 # 연결 성공 여부 확인
-if echo "$RESULT" | grep -qi "SSL connection using\|Connected\|HTTP/"; then
+if echo "$RESULT" | grep -qi "SSL connection using\|HTTP/"; then
     echo "[verify_tls] TLS 연결 성공"
 else
     echo "[verify_tls] 오류: TLS 연결 실패"


### PR DESCRIPTION
## 작업내용

### 주요 변경사항
- **entrypoint.sh**: `TLS_STAGE` 환경변수(1/2/3)에 따라 nginx 설정 자동 교체
  - Stage 1: Classical ECC (`nginx-ecc.conf`)
  - Stage 2: Hybrid PQC (`nginx-hybrid.conf`, X25519MLKEM768)
  - Stage 3: PQ-only (`nginx-pq.conf`, Dilithium3 인증서)
- **nginx/Dockerfile**: multi-stage 빌드로 Dilithium3 인증서 자동 생성 통합
- **docker-compose.yml**: `proxy-server` healthcheck 추가 (HTTP 80, 표준 curl 호환)
- **tester/verify_tls.sh**: Stage별 OQS-curl TLS 협상 검증 스크립트
- **devsecops-pipeline.yml**: `sleep 15` → healthcheck 기반 대기로 변경

### 코드 리뷰 반영
- `nginx-pq.conf` ssl_ecdh_curve 값 주석과 일치하도록 수정
- Dockerfile Alpine 호환을 위해 `bash` → `sh` 변경
- healthcheck를 HTTP 80 포트로 변경 (Stage 3 PQC-only 환경 호환)
- `gen-certs.sh` private key 권한 `chmod 600` 적용

## 주의 사항 및 참고 자료 (Optional)
- Stage 3 동작 시 OQS-curl이 설치된 클라이언트 필요 (`tls-tester` 컨테이너 사용)