### PR TITLE
fix(nginx): Stage 3 Dilithium3 인증서 호환성 문제 해결

### DIFF
--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -9,7 +9,10 @@ RUN mkdir -p /certs && \
     chmod 600 /certs/dilithium3.key
 
 # Stage 2: OQS-Nginx 본체
-FROM openquantumsafe/nginx@sha256:d02e7d6ec43bc3ea1c174f24d35af0e60a29eec0c9e6c39f356dba8b43f19f34
+# NOTE: sha256 pin(d02e7d6e...)이 oqs-ossl3:0.10.1로 생성한 Dilithium3 인증서를
+# OpenSSL SECLEVEL 정책으로 거부(ee key too small) → Stage 3 기동 실패.
+# 검증된 조합으로 되돌림.
+FROM openquantumsafe/nginx:0.11.0
 
 USER root
 

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -12,6 +12,7 @@ RUN mkdir -p /certs && \
 # NOTE: sha256 pin(d02e7d6e...)이 oqs-ossl3:0.10.1로 생성한 Dilithium3 인증서를
 # OpenSSL SECLEVEL 정책으로 거부(ee key too small) → Stage 3 기동 실패.
 # 검증된 조합으로 되돌림.
+# TODO(#79): oqs-ossl3 호환 버전 확정 후 sha256 pin 복구
 FROM openquantumsafe/nginx:0.11.0
 
 USER root


### PR DESCRIPTION
## 작업내용

PR #71 머지 이후 Stage 3 workflow_dispatch 기동 실패 해결.

### 원인

PR #71에서 `nginx/Dockerfile`의 nginx 이미지를 sha256 pin(`d02e7d6e...`)으로 변경하면서, 해당 이미지의 OpenSSL SECLEVEL 정책이 `oqs-ossl3:0.10.1`로 생성된 Dilithium3 인증서를 거부함.

로컬 `TLS_STAGE=3 docker compose up --build` 재현 로그:
```
[emerg] SSL_CTX_use_certificate failed
  (SSL: error:03000072:digital envelope routines::decode error
   error:0A00018F:SSL routines::ee key too small)
```

CI에서는 `pqc-proxy` 컨테이너가 60초간 `unhealthy` → timeout(exit 124)로 실패. develop 브랜치에서도 동일 증상 재현 확인.

### 변경 내용

```diff
- FROM openquantumsafe/nginx@sha256:d02e7d6ec43bc3ea1c174f24d35af0e60a29eec0c9e6c39f356dba8b43f19f34
+ FROM openquantumsafe/nginx:0.11.0
```

`:0.11.0` 태그는 `oqs-ossl3:0.10.1`과 호환 검증된 조합. Stage 1/2는 동일 nginx 이미지를 사용하므로 영향 없음.

### 검증

- 로컬 Stage 3 실행 → nginx 정상 기동, HTTP 301 응답 확인

## 주의 사항 및 참고 자료 (Optional)

- 추후 nginx 이미지를 sha256 pin으로 올리려면 cert-builder(oqs-ossl3)도 호환 버전으로 함께 업그레이드 필요