### PR TITLE
chore(ai-migration): RSA → ML-KEM migration (1 file(s))

### DIFF
--- a/examples/legacy_crypto_example.py
+++ b/examples/legacy_crypto_example.py
@@ -6,38 +6,25 @@
 이 파일을 ML-KEM(FIPS 203) 기반으로 자동 변환하는 PR을 생성합니다.
 """
 
-from cryptography.hazmat.primitives import hashes
-from cryptography.hazmat.primitives.asymmetric import padding, rsa
+from oqs import KeyEncapsulation
 
+
+# PQC migration: replaced RSA with ML-KEM
+kem = KeyEncapsulation("Kyber768")
 
 def generate_keypair():
-    """Generate an RSA-2048 keypair for key transport."""
-    private_key = rsa.generate_private_key(
-        public_exponent=65537,
-        key_size=2048,
-    )
-    return private_key
+    """Generate a keypair for key transport using ML-KEM."""
+    public_key = kem.generate_keypair()        # returns: bytes (public key)
+    return public_key
 
 
 def encrypt_session_key(public_key, session_key: bytes) -> bytes:
-    """Encrypt a session key using RSA-OAEP."""
-    return public_key.encrypt(
-        session_key,
-        padding.OAEP(
-            mgf=padding.MGF1(algorithm=hashes.SHA256()),
-            algorithm=hashes.SHA256(),
-            label=None,
-        ),
-    )
+    """Encapsulate a session key using ML-KEM. Returns shared secret."""
+    ciphertext, shared_secret = kem.encap_secret(public_key)
+    return ciphertext  # The shared secret can be used as the session key.
 
 
-def decrypt_session_key(private_key, ciphertext: bytes) -> bytes:
-    """Decrypt a session key using RSA-OAEP."""
-    return private_key.decrypt(
-        ciphertext,
-        padding.OAEP(
-            mgf=padding.MGF1(algorithm=hashes.SHA256()),
-            algorithm=hashes.SHA256(),
-            label=None,
-        ),
-    )
+def decrypt_session_key(ciphertext: bytes) -> bytes:
+    """Decapsulate a session key using ML-KEM."""
+    shared_secret = kem.decap_secret(ciphertext)
+    return shared_secret  # The shared secret is returned.


### PR DESCRIPTION
## 작업내용

AI 보조 PQC 마이그레이션. semgrep `crypto-classical.yaml` 룰이 탐지한 RSA 사용 코드를 ML-KEM(FIPS 203) / ML-DSA(FIPS 204)로 자동 변환.

### 변경 파일

- `examples/legacy_crypto_example.py` — finding 2건

### 검증 단계 (사람 리뷰)

1. 변경 diff 검토 — 비기능적 수정이 섞여 있지 않은지 확인
2. import / 의존성 변경 확인 (`oqs-python` 추가 여부)
3. 함수 시그니처 변화 확인 (ML-KEM은 `(ciphertext, shared_secret)` 튜플 반환)
4. 단위 테스트 통과 여부 확인

## 주의 사항 및 참고 자료 (Optional)

- 모델: gpt-4o-mini (GitHub Models)
- 자동 생성된 PR이므로 머지 전 반드시 사람 리뷰 필요
- 마이그레이션 처리 한도: 최대 3개 파일
- 자동 검증 통과 항목: Python 문법(`compile()`) + oqs-python API AST 검사