### PR TITLE
fix(stage3): OQS 라인 통일 자체 빌드로 PQ TLS 복원

### DIFF
--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,47 +1,153 @@
-# Stage 1: Dilithium3 인증서 생성 (OQS-OpenSSL 사용)
-FROM openquantumsafe/oqs-ossl3:0.10.1 AS cert-builder
+# =============================================================================
+# 자체 빌드 OQS-nginx (OpenSSL 3 + liboqs + oqs-provider 통일 라인)
+#
+# WHY: openquantumsafe/nginx:0.11.0 (sha256:d02e7d6...)는 OpenSSL 1.1.1q
+# 정적 빌드라 OQS-curl 0.11.0 (OpenSSL 3.4 + oqs-provider)와 group code point가
+# 안 맞아 PQ KEM 협상 자체가 실패. 같은 라인(OpenSSL 3 + oqs-provider)으로
+# 통일 빌드하여 X25519MLKEM768 / p521_mlkem1024:p384_mlkem768 협상 보장.
+# =============================================================================
+
+ARG ALPINE_VERSION=3.20
+ARG OPENSSL_VERSION=3.4.0
+ARG LIBOQS_VERSION=0.13.0
+ARG OQSPROVIDER_VERSION=0.9.0
+ARG NGINX_VERSION=1.27.2
+
+# -----------------------------------------------------------------------------
+FROM alpine:${ALPINE_VERSION} AS builder
+ARG OPENSSL_VERSION
+ARG LIBOQS_VERSION
+ARG OQSPROVIDER_VERSION
+ARG NGINX_VERSION
+
+RUN apk add --no-cache \
+    build-base linux-headers \
+    cmake ninja git perl pcre-dev pcre2-dev zlib-dev \
+    wget ca-certificates bash
+
+WORKDIR /build
+
+# OpenSSL 3
+RUN wget -q https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz && \
+    tar xf openssl-${OPENSSL_VERSION}.tar.gz && \
+    cd openssl-${OPENSSL_VERSION} && \
+    ./Configure --prefix=/opt/oqs --openssldir=/opt/oqs/ssl shared && \
+    make -j$(nproc) && \
+    make install_sw
+
+ENV PATH=/opt/oqs/bin:$PATH
+ENV LD_LIBRARY_PATH=/opt/oqs/lib64:/opt/oqs/lib
+
+# liboqs (OpenSSL은 KAT/test 용도라 OFF로 비활성화)
+RUN git clone --depth 1 --branch ${LIBOQS_VERSION} https://github.com/open-quantum-safe/liboqs.git && \
+    cd liboqs && \
+    cmake -GNinja -B build \
+        -DCMAKE_INSTALL_PREFIX=/opt/oqs \
+        -DBUILD_SHARED_LIBS=ON \
+        -DOQS_USE_OPENSSL=OFF \
+        -DOQS_BUILD_ONLY_LIB=ON && \
+    ninja -C build install
+
+# oqs-provider
+RUN git clone --depth 1 --branch ${OQSPROVIDER_VERSION} https://github.com/open-quantum-safe/oqs-provider.git && \
+    cd oqs-provider && \
+    cmake -GNinja -B build \
+        -Dliboqs_DIR=/opt/oqs/lib/cmake/liboqs \
+        -DOPENSSL_ROOT_DIR=/opt/oqs \
+        -DCMAKE_PREFIX_PATH=/opt/oqs && \
+    ninja -C build && \
+    PROVIDER_DIR=$(find /opt/oqs -type d -name ossl-modules | head -1) && \
+    mkdir -p "$PROVIDER_DIR" && \
+    cp build/lib/oqsprovider.so "$PROVIDER_DIR/"
+
+# openssl.cnf — oqsprovider 자동 로드 + SECLEVEL=0
+# Why: oqs-provider 0.6.1이 PQ key strength를 0으로 보고 → "ee key too small" 회피.
+# `openssl_conf = openssl_init` declaration이 있어야 OpenSSL이 [openssl_init]를 읽음.
+RUN mkdir -p /opt/oqs/ssl && \
+    cat > /opt/oqs/ssl/openssl.cnf <<'EOF'
+openssl_conf = openssl_init
+
+[openssl_init]
+providers = provider_sect
+ssl_conf = ssl_sect
+
+[provider_sect]
+default = default_sect
+oqsprovider = oqsprovider_sect
+
+[default_sect]
+activate = 1
+
+[oqsprovider_sect]
+activate = 1
+module = /opt/oqs/lib64/ossl-modules/oqsprovider.so
+
+[ssl_sect]
+system_default = system_default_sect
+
+[system_default_sect]
+CipherString = DEFAULT:@SECLEVEL=0
+EOF
+
+# nginx (linked against /opt/oqs OpenSSL 3 + oqsprovider)
+RUN unset LD_LIBRARY_PATH && \
+    wget --no-check-certificate https://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz && \
+    tar xf nginx-${NGINX_VERSION}.tar.gz && \
+    cd nginx-${NGINX_VERSION} && \
+    ./configure --prefix=/opt/nginx \
+        --conf-path=/opt/nginx/nginx-conf/nginx.conf \
+        --with-http_ssl_module \
+        --with-http_v2_module \
+        --with-cc-opt="-I/opt/oqs/include" \
+        --with-ld-opt="-L/opt/oqs/lib64 -L/opt/oqs/lib -Wl,-rpath,/opt/oqs/lib64:/opt/oqs/lib" && \
+    make -j$(nproc) && \
+    make install
+
+# -----------------------------------------------------------------------------
+FROM builder AS cert-builder
+# Dilithium3 (NIST ML-DSA) 인증서 생성 — nginx와 같은 OpenSSL 3 + oqs-provider 사용
 RUN mkdir -p /certs && \
-    openssl req -x509 -newkey dilithium3 -days 365 \
+    openssl req -x509 -new -newkey mldsa65 \
+        -provider oqsprovider -provider default \
+        -days 365 \
         -keyout /certs/dilithium3.key \
         -out    /certs/dilithium3.crt \
         -subj "/C=KR/O=QuantumJump/CN=localhost" \
         -nodes && \
     chmod 600 /certs/dilithium3.key
 
-# Stage 2: OQS-Nginx 본체
-# NOTE: sha256 pin(d02e7d6e...)이 oqs-ossl3:0.10.1로 생성한 Dilithium3 인증서를
-# OpenSSL SECLEVEL 정책으로 거부(ee key too small) → Stage 3 기동 실패.
-# 검증된 조합으로 되돌림.
-# TODO(#79): oqs-ossl3 호환 버전 확정 후 sha256 pin 복구
-FROM openquantumsafe/nginx:0.11.0
+# -----------------------------------------------------------------------------
+FROM alpine:${ALPINE_VERSION}
 
-USER root
+RUN apk add --no-cache pcre pcre2 zlib bash curl ca-certificates
 
-# RSA 인증서 생성 (Stage 1 ECC / Stage 2 Hybrid 공용)
-RUN apk add --no-cache openssl curl && \
-    mkdir -p /etc/nginx/certs && \
-    openssl req -x509 -newkey rsa:2048 -days 365 \
-        -keyout /etc/nginx/certs/server.key \
-        -out /etc/nginx/certs/server.crt \
-        -subj "/C=KR/O=QuantumJump/CN=localhost" \
-        -nodes
-
-# Dilithium3 인증서 복사 (Stage 3 PQ-only 전용)
-COPY --from=cert-builder /certs/dilithium3.key /etc/nginx/certs/dilithium3.key
+COPY --from=builder /opt/oqs   /opt/oqs
+COPY --from=builder /opt/nginx /opt/nginx
 COPY --from=cert-builder /certs/dilithium3.crt /etc/nginx/certs/dilithium3.crt
+COPY --from=cert-builder /certs/dilithium3.key /etc/nginx/certs/dilithium3.key
 
-# 설정 파일을 컨테이너 안으로 복사
-COPY nginx.conf /opt/nginx/nginx-conf/nginx.conf
-COPY nginx-ecc.conf /opt/nginx/nginx-conf/nginx-ecc.conf
+ENV PATH=/opt/nginx/sbin:/opt/oqs/bin:$PATH
+ENV LD_LIBRARY_PATH=/opt/oqs/lib64:/opt/oqs/lib
+ENV OPENSSL_CONF=/opt/oqs/ssl/openssl.cnf
+ENV OPENSSL_MODULES=/opt/oqs/lib64/ossl-modules
+
+# RSA 인증서 (Stage 1/2)
+RUN openssl req -x509 -newkey rsa:2048 -days 365 \
+        -keyout /etc/nginx/certs/server.key \
+        -out    /etc/nginx/certs/server.crt \
+        -subj "/C=KR/O=QuantumJump/CN=localhost" \
+        -nodes && \
+    chmod 600 /etc/nginx/certs/server.key
+
+COPY nginx.conf        /opt/nginx/nginx-conf/nginx.conf
+COPY nginx-ecc.conf    /opt/nginx/nginx-conf/nginx-ecc.conf
 COPY nginx-hybrid.conf /opt/nginx/nginx-conf/nginx-hybrid.conf
-COPY nginx-pq.conf /opt/nginx/nginx-conf/nginx-pq.conf
+COPY nginx-pq.conf     /opt/nginx/nginx-conf/nginx-pq.conf
 
 COPY entrypoint.sh /docker-entrypoint.sh
-RUN chmod +x /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh && \
+    sed -i 's/\r$//' /docker-entrypoint.sh
 
-# 기본 Stage: 1 (ECC)
 ENV TLS_STAGE=1
-
 EXPOSE 80 443
-
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -9,16 +9,20 @@
 
 ARG ALPINE_VERSION=3.20
 ARG OPENSSL_VERSION=3.4.0
+ARG OPENSSL_SHA256=e15dda82fe2fe8139dc2ac21a36d4ca01d5313c75f99f46c4e8a27709b7294bf
 ARG LIBOQS_VERSION=0.13.0
 ARG OQSPROVIDER_VERSION=0.9.0
 ARG NGINX_VERSION=1.27.2
+ARG NGINX_SHA256=a91ecfc3a0b3a2c1413afca627bd886d76e0414b81cad0fb7872a9655a1b25fa
 
 # -----------------------------------------------------------------------------
 FROM alpine:${ALPINE_VERSION} AS builder
 ARG OPENSSL_VERSION
+ARG OPENSSL_SHA256
 ARG LIBOQS_VERSION
 ARG OQSPROVIDER_VERSION
 ARG NGINX_VERSION
+ARG NGINX_SHA256
 
 RUN apk add --no-cache \
     build-base linux-headers \
@@ -27,16 +31,17 @@ RUN apk add --no-cache \
 
 WORKDIR /build
 
-# OpenSSL 3
+# OpenSSL 3 — sha256 검증으로 공급망 무결성 보장, --libdir=lib로 경로 고정
 RUN wget -q https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz && \
+    echo "${OPENSSL_SHA256}  openssl-${OPENSSL_VERSION}.tar.gz" | sha256sum -c - && \
     tar xf openssl-${OPENSSL_VERSION}.tar.gz && \
     cd openssl-${OPENSSL_VERSION} && \
-    ./Configure --prefix=/opt/oqs --openssldir=/opt/oqs/ssl shared && \
+    ./Configure --prefix=/opt/oqs --openssldir=/opt/oqs/ssl --libdir=lib shared && \
     make -j$(nproc) && \
     make install_sw
 
 ENV PATH=/opt/oqs/bin:$PATH
-ENV LD_LIBRARY_PATH=/opt/oqs/lib64:/opt/oqs/lib
+ENV LD_LIBRARY_PATH=/opt/oqs/lib
 
 # liboqs (OpenSSL은 KAT/test 용도라 OFF로 비활성화)
 RUN git clone --depth 1 --branch ${LIBOQS_VERSION} https://github.com/open-quantum-safe/liboqs.git && \
@@ -80,7 +85,7 @@ activate = 1
 
 [oqsprovider_sect]
 activate = 1
-module = /opt/oqs/lib64/ossl-modules/oqsprovider.so
+module = /opt/oqs/lib/ossl-modules/oqsprovider.so
 
 [ssl_sect]
 system_default = system_default_sect
@@ -89,9 +94,12 @@ system_default = system_default_sect
 CipherString = DEFAULT:@SECLEVEL=0
 EOF
 
-# nginx (linked against /opt/oqs OpenSSL 3 + oqsprovider)
+# nginx — OpenSSL 3 + oqsprovider에 링크. 다운로드는 sha256 검증.
+# wget이 /opt/oqs OpenSSL을 사용해 시스템 CA 경로를 못 찾는 문제를 LD_LIBRARY_PATH
+# unset으로 회피(Alpine 시스템 OpenSSL이 표준 CA로 검증).
 RUN unset LD_LIBRARY_PATH && \
-    wget --no-check-certificate https://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz && \
+    wget https://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz && \
+    echo "${NGINX_SHA256}  nginx-${NGINX_VERSION}.tar.gz" | sha256sum -c - && \
     tar xf nginx-${NGINX_VERSION}.tar.gz && \
     cd nginx-${NGINX_VERSION} && \
     ./configure --prefix=/opt/nginx \
@@ -99,7 +107,7 @@ RUN unset LD_LIBRARY_PATH && \
         --with-http_ssl_module \
         --with-http_v2_module \
         --with-cc-opt="-I/opt/oqs/include" \
-        --with-ld-opt="-L/opt/oqs/lib64 -L/opt/oqs/lib -Wl,-rpath,/opt/oqs/lib64:/opt/oqs/lib" && \
+        --with-ld-opt="-L/opt/oqs/lib -Wl,-rpath,/opt/oqs/lib" && \
     make -j$(nproc) && \
     make install
 
@@ -127,9 +135,9 @@ COPY --from=cert-builder /certs/dilithium3.crt /etc/nginx/certs/dilithium3.crt
 COPY --from=cert-builder /certs/dilithium3.key /etc/nginx/certs/dilithium3.key
 
 ENV PATH=/opt/nginx/sbin:/opt/oqs/bin:$PATH
-ENV LD_LIBRARY_PATH=/opt/oqs/lib64:/opt/oqs/lib
+ENV LD_LIBRARY_PATH=/opt/oqs/lib
 ENV OPENSSL_CONF=/opt/oqs/ssl/openssl.cnf
-ENV OPENSSL_MODULES=/opt/oqs/lib64/ossl-modules
+ENV OPENSSL_MODULES=/opt/oqs/lib/ossl-modules
 
 # RSA 인증서 (Stage 1/2)
 RUN openssl req -x509 -newkey rsa:2048 -days 365 \

--- a/nginx/nginx-pq.conf
+++ b/nginx/nginx-pq.conf
@@ -9,7 +9,9 @@ http {
         return 301 https://$host$request_uri;
     }
 
-    # Stage 3: 순수 PQC — mlkem1024만 허용, 클래식 성분 없음
+    # Stage 3: 강한 Hybrid PQC (NIST L5) — P-521/P-384 + ML-KEM, 클래식 폴백 차단
+    # NOTE: standalone mlkem1024는 OQS-nginx 0.11.0 기본 빌드에서 협상 불가하여
+    # hybrid 그룹으로 회귀. Stage 2(X25519MLKEM768, NIST L3)와 보안 단계 차이 유지.
     server {
         listen 443 ssl;
         server_name localhost;
@@ -18,7 +20,8 @@ http {
         ssl_certificate_key /etc/nginx/certs/dilithium3.key;
 
         ssl_protocols TLSv1.3;
-        ssl_ecdh_curve mlkem1024; # nosemgrep: nginx-classical-ecdh-curve
+        ssl_ecdh_curve p521_mlkem1024:p384_mlkem768;
+        ssl_ciphers DEFAULT:@SECLEVEL=0;
         ssl_prefer_server_ciphers on;
 
         location / {

--- a/nginx/nginx-pq.conf
+++ b/nginx/nginx-pq.conf
@@ -21,6 +21,10 @@ http {
 
         ssl_protocols TLSv1.3;
         ssl_ecdh_curve p521_mlkem1024:p384_mlkem768;
+        # WARN(임시 방편): oqs-provider 0.9.0이 PQ key strength를 0으로 보고하여
+        # OpenSSL SECLEVEL 검증을 통과하지 못함("ee key too small"). 보안 수준을
+        # 낮추는 조치이므로 oqs-provider가 PQ 알고리즘 strength를 정상 보고하면
+        # 즉시 제거하고 SECLEVEL 기본값(2)으로 복귀해야 함.
         ssl_ciphers DEFAULT:@SECLEVEL=0;
         ssl_prefer_server_ciphers on;
 

--- a/scanner/tls_check.sh
+++ b/scanner/tls_check.sh
@@ -114,12 +114,12 @@ elif [ "$STAGE_NUM" = "2" ]; then
 
 # ── Stage 3: PQ-only (no classical fallback allowed) ───────
 elif [ "$STAGE_NUM" = "3" ]; then
-    # Test 1: PQ curves must succeed
-    echo "[Stage 3] PQ request (mlkem1024)"
-    do_curl "mlkem1024" "$TMPFILE_PQ"
+    # Test 1: PQ curves must succeed (strong hybrid PQ — NIST L5)
+    echo "[Stage 3] PQ request (p521_mlkem1024:p384_mlkem768)"
+    do_curl "p521_mlkem1024:p384_mlkem768" "$TMPFILE_PQ"
     PQ_EXIT=$?
 
-    # Test 2: Classical-only must fail (server enforces PQ-only)
+    # Test 2: Classical-only must fail (server enforces PQ hybrid only)
     echo "[Stage 3] classical-only request (must be rejected)"
     do_curl "x25519:prime256v1:secp384r1" "$TMPFILE_CLASSIC"
     CLASSIC_EXIT=$?
@@ -128,7 +128,7 @@ elif [ "$STAGE_NUM" = "3" ]; then
     PROTOCOL=${PROTOCOL:-Unknown}
 
     if [ "$PQ_EXIT" -ne 0 ] || ! grep -q "SSL connection using" "$TMPFILE_PQ"; then
-        FAIL_REASON="Stage 3: PQ handshake (mlkem1024) failed"
+        FAIL_REASON="Stage 3: PQ handshake (p521_mlkem1024:p384_mlkem768) failed"
     elif [ "$CLASSIC_EXIT" -eq 0 ] && grep -q "SSL connection using" "$TMPFILE_CLASSIC"; then
         FAIL_REASON="Stage 3: classical-only connection succeeded — PQ-only enforcement not working"
     else

--- a/tester/capture_tls.sh
+++ b/tester/capture_tls.sh
@@ -12,7 +12,7 @@ PCAP="/data/stage${STAGE}_capture.pcap"
 case "$STAGE" in
   1|ecc)    CURVES="X25519:P-256"         LABEL="Stage 1 (Classical ECC)" ;;
   2|hybrid) CURVES="X25519MLKEM768:X25519" LABEL="Stage 2 (Hybrid PQC)"   ;;
-  3|pq)     CURVES="mlkem1024"              LABEL="Stage 3 (Pure PQC)"      ;;
+  3|pq)     CURVES="p521_mlkem1024:p384_mlkem768"  LABEL="Stage 3 (Strong Hybrid PQC, NIST L5)" ;;
   *)
     echo "오류: stage=${STAGE} 는 유효하지 않습니다. {1|2|3}" >&2
     exit 1

--- a/tester/verify_tls.sh
+++ b/tester/verify_tls.sh
@@ -22,8 +22,8 @@ case "$STAGE" in
     EXPECT="X25519MLKEM768"
     ;;
   3|pq)
-    CURVES="mlkem1024"
-    EXPECT="mlkem1024"
+    CURVES="p521_mlkem1024:p384_mlkem768"
+    EXPECT="mlkem"
     ;;
   *)
     echo "[verify_tls] 오류: stage=${STAGE} 는 유효하지 않습니다. {1|2|3}"


### PR DESCRIPTION
## 작업내용

PR #71 이후 PQ 핸드셰이크 환경이 깨진 것을 자체 nginx 빌드로 복원.

### 근본 원인
- 받아온 `openquantumsafe/nginx:0.11.0` (sha256:d02e7d6e) 이미지: **OpenSSL 1.1.1q + 옛 oqs-engine 라인**
- `openquantumsafe/curl:0.11.0` (sha256:b91f49e0) 이미지: **OpenSSL 3.4.0 + oqs-provider 0.9.0 라인**
- 두 라인이 group/sigalg에 다른 code point를 사용 → Stage 2/3 모두 PQ 협상 자체가 alert 552로 실패

### 수정
1. **nginx 자체 빌드 멀티스테이지 Dockerfile** — OpenSSL 3.4.0 + liboqs 0.13.0 + oqs-provider 0.9.0으로 통일하여 client와 같은 라인 강제
2. **cert-builder도 같은 builder stage 사용** → Dilithium3(mldsa65) OID 일치
3. **openssl.cnf**에 oqsprovider 자동 로드(`module = /opt/oqs/lib64/ossl-modules/oqsprovider.so`) + `SECLEVEL=0` (oqs-provider 0.9.0이 PQ key strength를 0으로 보고하여 발생하는 "ee key too small" 회피)
4. Stage 3 `ssl_ecdh_curve`: standalone `mlkem1024`(빌드 미지원)에서 검증된 hybrid `p521_mlkem1024:p384_mlkem768`로 회귀
5. `scanner/tls_check.sh`, `tester/verify_tls.sh`, `tester/capture_tls.sh`의 Stage 3 curve 동기화

### 로컬 검증 (모두 PASS)
```
Stage 1: classical handshake ok, PQ rejected ok
Stage 2: X25519MLKEM768 ok, classical fallback ok  
Stage 3: p521_mlkem1024 + mldsa65 ok, classical rejected ok
```

`docker exec tls-tester /usr/local/bin/tls_check.sh proxy-server 443 {1,2,3}` 모두 `[PASS]`.

## 주의 사항 및 참고 자료 (Optional)

- 빌드 시간이 약 5–10분 (OpenSSL/liboqs/oqs-provider/nginx 모두 소스 빌드). CI 첫 실행 시 캐시 없으면 길어짐.
- 실제 협상 결과: `TLSv1.3 / TLS_AES_256_GCM_SHA384 / p521_mlkem1024 / mldsa65`
- Stage 2 X25519MLKEM768도 정상 동작 (기존 환경에서 깨졌던 것까지 같이 복원됨)