### PR TITLE
Fix: Stage 3 캡처 비교 지원 및 verify_tls.sh EXPECT 패턴 구체화

### DIFF
--- a/tester/compare_captures.sh
+++ b/tester/compare_captures.sh
@@ -25,14 +25,14 @@ print_handshake() {
   echo "  파일: ${PCAP} (총 ${TOTAL}패킷)"
   echo ""
 
-  # ClientHello: 클라이언트가 제안한 지원 그룹
+  # ClientHello: 직접 필드 추출 (verbose 파싱보다 효율적)
   echo "  [ClientHello] 클라이언트 제안 그룹:"
   tshark -r "$PCAP" \
     -Y "tls.handshake.type == 1" \
-    -V 2>/dev/null \
-    | grep -iE "supported group|group:" \
-    | sed 's/^/    /' \
-    | head -10
+    -T fields \
+    -e tls.handshake.extensions_supported_group \
+    2>/dev/null \
+    | tr ',' '\n' | sed 's/^/    /'
   echo ""
 
   # ServerHello: 서버가 선택한 키교환 그룹
@@ -41,7 +41,7 @@ print_handshake() {
     -Y "tls.handshake.type == 2" \
     -V 2>/dev/null \
     | grep -iE "key share entry|group:|named group" \
-    | sed 's/^/    /' \
+    | tr -d '\r' | cut -c1-80 | sed 's/^/    /' \
     | head -10
   echo ""
 }
@@ -61,47 +61,34 @@ MISSING=0
 [ ! -f "$PCAP3" ] && echo "  Stage 3 캡처 없음" && MISSING=1
 [ "$MISSING" -eq 1 ] && exit 1
 
-# Stage 1: X25519 (Classical ECC)
+# Stage 1: X25519 (0x001d)
 S1_GROUP=$(tshark -r "$PCAP1" -Y "tls.handshake.type==2" -V 2>/dev/null \
   | grep -iE "key share entry|named group|group:" | head -5)
 
-# Stage 2: X25519MLKEM768 (Hybrid PQC, group ID 4588 / 0x11EC)
+# Stage 2: X25519MLKEM768 (0x11ec = 4588)
 S2_GROUP=$(tshark -r "$PCAP2" -Y "tls.handshake.type==2" -V 2>/dev/null \
   | grep -iE "key share entry|named group|group:" | head -5)
 
-# Stage 3: mlkem1024 (Pure PQC) — 핸드셰이크 실패 시 ClientHello 기반 판정
-# OQS 라이브러리 버전 불일치로 ServerHello 없을 수 있음 → ClientHello로 클라이언트 정책 검증
-# tshark가 0x0202를 구 IANA 초안명 'frodo976aes'로 표시할 수 있음 → verbose 파싱 사용
-S3_CLIENT_GROUP=$(tshark -r "$PCAP3" -Y "tls.handshake.type==1" -V 2>/dev/null \
-  | grep -iE "supported group:|key share entry" | head -5)
-S3_SERVER_GROUP=$(tshark -r "$PCAP3" -Y "tls.handshake.type==2" -V 2>/dev/null \
+# Stage 3: p521_mlkem1024 (0x11ee = 4590) 또는 p384_mlkem768 (0x11ef = 4591) — Hybrid PQC
+S3_GROUP=$(tshark -r "$PCAP3" -Y "tls.handshake.type==2" -V 2>/dev/null \
   | grep -iE "key share entry|named group|group:" | head -5)
 
 echo ""
 echo "  Stage 1 협상 그룹: $(echo "$S1_GROUP" | tr '\n' ' ' | cut -c1-80)"
 echo "  Stage 2 협상 그룹: $(echo "$S2_GROUP" | tr '\n' ' ' | cut -c1-80)"
-if [ -n "$S3_SERVER_GROUP" ]; then
-  echo "  Stage 3 협상 그룹: $(echo "$S3_SERVER_GROUP" | tr '\n' ' ' | cut -c1-80)"
-else
-  echo "  Stage 3 ClientHello 그룹: ${S3_CLIENT_GROUP} (서버 응답 없음 — OQS 버전 불일치)"
-fi
+echo "  Stage 3 협상 그룹: $(echo "$S3_GROUP" | tr '\n' ' ' | cut -c1-80)"
 echo ""
 
-# X25519 (29) vs X25519MLKEM768 (4588/0x11EC) vs mlkem1024 (514/0x0202)
+# X25519 (group ID 29 / 0x001d)
 S1_OK=0
+# X25519MLKEM768 (group ID 4588 / 0x11ec)
 S2_OK=0
+# p521_mlkem1024 (0x11ee=4590) 또는 p384_mlkem768 (0x11ef=4591)
 S3_OK=0
 
 echo "$S1_GROUP" | grep -qiE "x25519|29\b" && S1_OK=1
-echo "$S2_GROUP" | grep -qiE "mlkem|4588|0x11ec|11ec" && S2_OK=1
-
-# Stage 3: ClientHello가 mlkem1024(0x0202 / frodo976aes / 514)만 제안하고 x25519 없으면 PASS
-# tshark 버전에 따라 그룹명이 frodo976aes 또는 mlkem1024로 다르게 표시될 수 있음
-S3_HAS_PQC=0
-S3_HAS_X25519=0
-echo "$S3_CLIENT_GROUP" | grep -qiE "0x0202|frodo976aes|mlkem1024|514\b" && S3_HAS_PQC=1
-echo "$S3_CLIENT_GROUP" | grep -qiE "x25519|0x001d|29\b" && S3_HAS_X25519=1
-[ "$S3_HAS_PQC" -eq 1 ] && [ "$S3_HAS_X25519" -eq 0 ] && S3_OK=1
+echo "$S2_GROUP" | grep -qiE "4588|0x11ec|11ec" && S2_OK=1
+echo "$S3_GROUP" | grep -qiE "4590|0x11ee|11ee|4591|0x11ef|11ef" && S3_OK=1
 
 if [ "$S1_OK" -eq 1 ]; then
   echo "  Stage 1: PASS — X25519 (Classical ECC) 협상 확인"
@@ -116,17 +103,9 @@ else
 fi
 
 if [ "$S3_OK" -eq 1 ]; then
-  if [ -n "$S3_SERVER_GROUP" ]; then
-    echo "  Stage 3: PASS — mlkem1024 (Pure PQC) 클라이언트 정책 및 서버 협상 확인"
-  else
-    echo "  Stage 3: PASS (클라이언트 정책) — ClientHello에 mlkem1024(0x0202)만 제안, ECC 제외"
-    echo "           ※ 서버 응답 없음: OQS nginx/curl 버전 불일치로 핸드셰이크 미완료"
-    echo "             (CI에서도 continue-on-error로 처리되는 알려진 호환성 이슈)"
-  fi
-elif [ "$S3_HAS_X25519" -eq 1 ]; then
-  echo "  Stage 3: FAIL — ClientHello에 x25519 혼용됨 (Pure PQC 정책 위반)"
+  echo "  Stage 3: PASS — p521_mlkem1024/p384_mlkem768 (Hybrid PQC) 협상 확인"
 else
-  echo "  Stage 3: 확인 필요 — 그룹 ID를 직접 확인하세요 (ClientHello: ${S3_CLIENT_GROUP})"
+  echo "  Stage 3: 확인 필요 — 그룹 ID를 직접 확인하세요"
 fi
 
 echo ""

--- a/tester/verify_tls.sh
+++ b/tester/verify_tls.sh
@@ -23,7 +23,7 @@ case "$STAGE" in
     ;;
   3|pq)
     CURVES="p521_mlkem1024:p384_mlkem768"
-    EXPECT="mlkem"
+    EXPECT="p521_mlkem|p384_mlkem"
     ;;
   *)
     echo "[verify_tls] 오류: stage=${STAGE} 는 유효하지 않습니다. {1|2|3}"
@@ -44,7 +44,7 @@ else
 fi
 
 # Stage별 알고리즘 확인
-if echo "$RESULT" | grep -qi "$EXPECT"; then
+if echo "$RESULT" | grep -qiE "$EXPECT"; then
     echo "[verify_tls] PASS — Stage $STAGE 알고리즘 협상 확인됨 ($EXPECT)"
     exit 0
 else


### PR DESCRIPTION
 ## Summary

  - `compare_captures.sh`: Stage 3(`p521_mlkem1024`/`p384_mlkem768`) 비교 분기 추가
  - `compare_captures.sh`: ClientHello 추출을 `-T fields` 방식으로 개선 (verbose 파싱 제거)
  - `compare_captures.sh`: ServerHello 출력 포맷팅 `tr`/`cut`으로 Stage 1/2와 통일
  - `verify_tls.sh`: Stage 3 EXPECT `"mlkem"` → `"p521_mlkem|p384_mlkem"` (Stage 2 오판정 방지)
  - `verify_tls.sh`: `grep -qi` → `grep -qiE` (ERE 교번 패턴 지원)

  ## 배경

  PR #85 머지 시 Gemini Code Assist 봇이 지적한 3건을 후속 처리합니다.
  - Stage 3 검증 로직이 실제 hybrid 구성(`p521_mlkem1024`)과 불일치
  - tshark 필드 추출 비효율
  - Stage 3 출력 포맷팅 불일치

  ## Test plan

  - [ ] `capture_tls.sh 3` 실행 후 `compare_captures.sh`에서 Stage 3 PASS 확인
  - [ ] `verify_tls.sh pqc-proxy 443 3` 실행 시 PASS 확인
  - [ ] Stage 2에서 `verify_tls.sh pqc-proxy 443 3` 실행 시 FAIL 확인 (오판정 방지 검증)