### PR TITLE
fix(tester): verify_tls.sh를 tester 이미지에 포함

### DIFF
--- a/tester/Dockerfile
+++ b/tester/Dockerfile
@@ -14,12 +14,15 @@ RUN apk add --no-cache \
 COPY scanner/tls_check.sh /usr/local/bin/tls_check.sh
 COPY tester/capture_tls.sh /usr/local/bin/capture_tls.sh
 COPY tester/compare_captures.sh /usr/local/bin/compare_captures.sh
+COPY tester/verify_tls.sh /usr/local/bin/verify_tls.sh
 COPY perf-rollback/perf_check.sh /usr/local/bin/perf_check.sh
 RUN sed -i 's/\r//' /usr/local/bin/tls_check.sh \
                     /usr/local/bin/capture_tls.sh \
                     /usr/local/bin/compare_captures.sh \
+                    /usr/local/bin/verify_tls.sh \
                     /usr/local/bin/perf_check.sh && \
     chmod +x /usr/local/bin/tls_check.sh \
              /usr/local/bin/capture_tls.sh \
              /usr/local/bin/compare_captures.sh \
+             /usr/local/bin/verify_tls.sh \
              /usr/local/bin/perf_check.sh


### PR DESCRIPTION
## 작업내용

PR #80/#86에서 추가·개선한 `verify_tls.sh`가 `tester/Dockerfile`의 COPY 목록에 누락되어 `docker exec tls-tester verify_tls.sh ...` 실행 시 `no such file or directory` 발생. tester 이미지에 `/usr/local/bin/verify_tls.sh`로 복사하도록 추가.

### 로컬 검증
- Stage 1: PASS — X25519
- Stage 2: PASS — X25519MLKEM768
- Stage 3: PASS — p521_mlkem|p384_mlkem

## 주의 사항 및 참고 자료 (Optional)

main 머지 직전 발견된 누락이라 짧은 hotfix로 처리. CRLF 정규화 + chmod도 기존 패턴과 동일하게 추가.