### PR TITLE
chore(ai-migration): RSA → ML-KEM auto migration

### DIFF
--- a/app/demo_rsa_keygen.py
+++ b/app/demo_rsa_keygen.py
@@ -1,12 +1,13 @@
 """Demo file to trigger AI migration."""
-from cryptography.hazmat.primitives.asymmetric import rsa
+from oqs import KeyEncapsulation
 
-
+# PQC migration: replaced RSA with ML-KEM
 def generate_user_key():
-    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
-    return private_key
+    kem = KeyEncapsulation("Kyber768")
+    public_key = kem.generate_keypair()  # returns: bytes (public key)
+    return kem, public_key
 
 
 if __name__ == "__main__":
-    key = generate_user_key()
+    kem, key = generate_user_key()
     print("Key generated")

--- a/artifacts/eval/benchmark/patterns/01_cryptography_keygen_simple.py
+++ b/artifacts/eval/benchmark/patterns/01_cryptography_keygen_simple.py
@@ -3,13 +3,11 @@
 input: RSA-2048 키 쌍 생성 후 (private, public) 반환.
 expected migration target: ML-KEM-768 키 쌍 생성.
 """
-from cryptography.hazmat.primitives.asymmetric import rsa
+from oqs import KeyEncapsulation
 
 
+# PQC migration: replaced RSA with ML-KEM
 def generate_keypair():
-    private_key = rsa.generate_private_key(
-        public_exponent=65537,
-        key_size=2048,
-    )
-    public_key = private_key.public_key()
-    return private_key, public_key
+    kem = KeyEncapsulation("Kyber768")
+    public_key = kem.generate_keypair()        # returns: bytes (public key)
+    return kem, public_key

--- a/artifacts/eval/benchmark/patterns/05_cryptography_keygen_complex.py
+++ b/artifacts/eval/benchmark/patterns/05_cryptography_keygen_complex.py
@@ -6,38 +6,34 @@ raw bytes로 저장 (또는 PKCS#8 PEM 별도 인코딩 — 정답에서 raw byt
 """
 from pathlib import Path
 
-from cryptography.hazmat.primitives import serialization
-from cryptography.hazmat.primitives.asymmetric import rsa
+from oqs import KeyEncapsulation
 
 
 class KeyManager:
     def __init__(self, key_dir: Path):
         self.key_dir = Path(key_dir)
         self.key_dir.mkdir(parents=True, exist_ok=True)
-        self.private_key = None
+        self.kem = None
         self.public_key = None
 
+    # PQC migration: replaced RSA with ML-KEM
     def generate(self) -> None:
-        self.private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
-        self.public_key = self.private_key.public_key()
+        self.kem = KeyEncapsulation("Kyber768")
+        self.public_key = self.kem.generate_keypair()  # returns: bytes (public key)
 
     def save(self, name: str) -> None:
-        if self.private_key is None:
+        if self.kem is None:
             raise RuntimeError("키가 생성되지 않음")
-        priv_pem = self.private_key.private_bytes(
-            encoding=serialization.Encoding.PEM,
-            format=serialization.PrivateFormat.PKCS8,
-            encryption_algorithm=serialization.NoEncryption(),
-        )
-        pub_pem = self.public_key.public_bytes(
-            encoding=serialization.Encoding.PEM,
-            format=serialization.PublicFormat.SubjectPublicKeyInfo,
-        )
-        (self.key_dir / f"{name}.priv.pem").write_bytes(priv_pem)
-        (self.key_dir / f"{name}.pub.pem").write_bytes(pub_pem)
+        # Note: No PEM format for KEM keys, saving raw bytes is assumed
+        priv_bytes = self.kem.secret_key  # This is a placeholder; actual storage logic may vary
+        pub_bytes = self.public_key
+        (self.key_dir / f"{name}.priv").write_bytes(priv_bytes)
+        (self.key_dir / f"{name}.pub").write_bytes(pub_bytes)
 
     def load(self, name: str) -> None:
-        priv_pem = (self.key_dir / f"{name}.priv.pem").read_bytes()
-        pub_pem = (self.key_dir / f"{name}.pub.pem").read_bytes()
-        self.private_key = serialization.load_pem_private_key(priv_pem, password=None)
-        self.public_key = serialization.load_pem_public_key(pub_pem)
+        priv_bytes = (self.key_dir / f"{name}.priv").read_bytes()
+        pub_bytes = (self.key_dir / f"{name}.pub").read_bytes()
+        # Placeholder for loading logic; actual implementation may vary
+        self.kem = KeyEncapsulation("Kyber768")  # Re-instantiate for secret key access
+        self.kem.secret_key = priv_bytes  # This is a placeholder; actual loading logic may vary
+        self.public_key = pub_bytes


### PR DESCRIPTION
AI-generated migration by ai-migration workflow.

Files migrated:
- app/demo_rsa_keygen.py
- artifacts/eval/benchmark/patterns/01_cryptography_keygen_simple.py  
- artifacts/eval/benchmark/patterns/05_cryptography_keygen_complex.py

Total findings: 6
AST validation: PASS
Generated by: GitHub Models gpt-4o-mini